### PR TITLE
M8F-175: Fix 404 error for config.js in network tab

### DIFF
--- a/extensions/m8flow-frontend/docker_build/nginx.conf.template
+++ b/extensions/m8flow-frontend/docker_build/nginx.conf.template
@@ -16,12 +16,6 @@ server {
         try_files $uri =404;
     }
 
-    # Runtime config must never be stale
-    location = /config.js {
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
-    }
 
     # SPA fallback -- index.html must always be revalidated
     location / {

--- a/extensions/m8flow-frontend/index.html
+++ b/extensions/m8flow-frontend/index.html
@@ -21,7 +21,6 @@
     <script>
       window.spiffworkflowFrontendJsenv = {};
     </script>
-    <script src="/config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## JIRA Ticket

[M8F-175](https://aottech.atlassian.net/browse/M8F-175)

## Description

This PR resolves a persistent **404 Not Found** error for `/config.js` when running the application in Docker/Nginx environments.

### The Issue
The `extensions/m8flow-frontend/index.html` file included a redundant `<script src="/config.js"></script>` tag. In the `spiffworkflow` architecture used in this project, there is **no external `config.js` file** created on disk. 

Instead, the system's entrypoint script (`boot_server_in_docker`) dynamically injects environment variables (such as `BACKEND_BASE_URL` and `MULTI_TENANT_ON`) directly into a script block within `index.html` at container startup. 

Because the tag was present but the file did not exist, browsers reported a 404 error, and an unnecessary Nginx location block was attempting to apply caching rules to a non-existent resource.

### The Solution
The fix involves removing redundant configuration references from the extension frontend to match the standard architecture:

1.  **`index.html`**: Removed the `<script src="/config.js"></script>` tag. The application correctly receives its runtime configuration through the `window.spiffworkflowFrontendJsenv = {};` script block, which is populated by the existing Docker entrypoint logic.
2.  **`nginx.conf.template`**: Removed the `location = /config.js` block. This block was for the non-existent file and is now unnecessary.


## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [x] Frontend
- [ ] Documentation

## Testing

### Verification of Configuration Loading
- **Tested Environment**: Local Docker container running Nginx.
- **Verification**: Confirmed that when using `MULTI_TENANT_ON=true` and `BACKEND_BASE_URL=http://localhost:7001`, the application correctly reads these values through `window.spiffworkflowFrontendJsenv` in the browser console.
- **Observation**: Successfully loaded the application's configuration without needing an external `config.js` file.

### Verification of 404 Result
- **Verification**: Observed the browser's Network tab.
- **Observation**: Confirmed that the 404 for `/config.js` is now gone, as the browser no longer attempts to request it.


## Related Issues

Closes #



[M8F-175]: https://aottech.atlassian.net/browse/M8F-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ