### PR TITLE
Tenant Creation from API to UI (Super Admin)

### DIFF
--- a/extensions/m8flow-frontend/src/enums/TenantModalType.ts
+++ b/extensions/m8flow-frontend/src/enums/TenantModalType.ts
@@ -1,4 +1,5 @@
 export enum TenantModalType {
+    CREATE_TENANT = "CREATE_TENANT",
     EDIT_TENANT = "EDIT_TENANT",
     DELETE_TENANT = "DELETE_TENANT",
 }

--- a/extensions/m8flow-frontend/src/services/TenantService.ts
+++ b/extensions/m8flow-frontend/src/services/TenantService.ts
@@ -22,6 +22,18 @@ export interface UpdateTenantRequest {
     status?: TenantStatus;
 }
 
+export interface CreateTenantRequest {
+    realm_id: string;
+    display_name: string;
+}
+
+export interface CreateTenantResponse {
+    realm: string;
+    displayName: string;
+    keycloak_realm_id: string;
+    id: string;
+}
+
 const TenantService = {
     /**
      * Get all tenants
@@ -31,6 +43,34 @@ const TenantService = {
             HttpService.makeCallToBackend({
                 path: `${BASE_PATH}/tenants`,
                 httpMethod: "GET",
+                successCallback: resolve,
+                failureCallback: reject,
+            });
+        });
+    },
+
+    /**
+     * Create a tenant realm
+     */
+    createTenant: (data: CreateTenantRequest): Promise<CreateTenantResponse> => {
+        const realmId = data.realm_id.trim();
+        const displayName = data.display_name.trim();
+
+        if (!realmId) {
+            return Promise.reject(new Error("Tenant slug cannot be empty"));
+        }
+        if (!displayName) {
+            return Promise.reject(new Error("Tenant display name cannot be empty"));
+        }
+
+        return new Promise((resolve, reject) => {
+            HttpService.makeCallToBackend({
+                path: `${BASE_PATH}/tenant-realms`,
+                httpMethod: "POST",
+                postBody: {
+                    realm_id: realmId,
+                    display_name: displayName,
+                },
                 successCallback: resolve,
                 failureCallback: reject,
             });

--- a/extensions/m8flow-frontend/src/views/TenantModal.tsx
+++ b/extensions/m8flow-frontend/src/views/TenantModal.tsx
@@ -1,22 +1,16 @@
 import {
+  Alert,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
   Stack,
   TextField,
 } from "@mui/material";
 import { useEffect, useState } from "react";
-import TenantService, {
-  Tenant,
-  EditableTenantStatus,
-} from "../services/TenantService";
+import TenantService, { Tenant } from "../services/TenantService";
 import { TenantModalType } from "../enums/TenantModalType";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 
@@ -25,7 +19,44 @@ interface TenantModalProps {
   type: TenantModalType;
   tenant: Tenant | null;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (message: string) => void;
+}
+
+const MAX_SLUG_LENGTH = 15;
+const MAX_DISPLAY_NAME_LENGTH = 50;
+const TENANT_SLUG_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function validateTenantSlug(value: string): string {
+  if (!value) {
+    return "Tenant slug cannot be empty";
+  }
+  if (value.length > MAX_SLUG_LENGTH) {
+    return `Tenant slug must be ${MAX_SLUG_LENGTH} characters or fewer`;
+  }
+  if (!TENANT_SLUG_PATTERN.test(value)) {
+    return "Tenant slug can only contain letters, numbers, hyphens, and underscores";
+  }
+  return "";
+}
+
+function validateDisplayName(value: string): string {
+  if (!value) {
+    return "Tenant display name cannot be empty";
+  }
+  if (value.length > MAX_DISPLAY_NAME_LENGTH) {
+    return `Tenant display name must be ${MAX_DISPLAY_NAME_LENGTH} characters or fewer`;
+  }
+  return "";
+}
+
+function getErrorMessage(error: any): string {
+  if (typeof error?.detail === "string" && error.detail) {
+    return error.detail;
+  }
+  if (typeof error?.message === "string" && error.message) {
+    return error.message;
+  }
+  return "";
 }
 
 export default function TenantModal({
@@ -37,38 +68,80 @@ export default function TenantModal({
 }: TenantModalProps) {
   const [loading, setLoading] = useState(false);
 
+  // Create State
+  const [createRealmId, setCreateRealmId] = useState("");
+  const [createDisplayName, setCreateDisplayName] = useState("");
+  const [createRealmIdError, setCreateRealmIdError] = useState("");
+  const [createDisplayNameError, setCreateDisplayNameError] = useState("");
+
   // Edit State
   const [editName, setEditName] = useState("");
-  const [editStatus, setEditStatus] = useState<EditableTenantStatus>("ACTIVE");
+  const [editNameError, setEditNameError] = useState("");
+  const [submitError, setSubmitError] = useState("");
 
   useEffect(() => {
-    if (open && tenant) {
-      if (type === TenantModalType.EDIT_TENANT) {
+    if (open) {
+      if (type === TenantModalType.CREATE_TENANT) {
+        setCreateRealmId("");
+        setCreateDisplayName("");
+      } else if (tenant && type === TenantModalType.EDIT_TENANT) {
         setEditName(tenant.name);
-        setEditStatus(tenant.status === "DELETED" ? "INACTIVE" : tenant.status);
       }
     } else if (!open) {
       // Reset state when modal closes to prevent stale data
+      setCreateRealmId("");
+      setCreateDisplayName("");
       setEditName("");
-      setEditStatus("ACTIVE");
     }
+    setCreateRealmIdError("");
+    setCreateDisplayNameError("");
+    setEditNameError("");
+    setSubmitError("");
   }, [open, tenant, type]);
 
   const handleSubmit = async () => {
-    if (!tenant) return;
+    let hasValidationError = false;
+    setCreateRealmIdError("");
+    setCreateDisplayNameError("");
+    setEditNameError("");
+    setSubmitError("");
 
-    // Validate name for edit operation
-    if (type === TenantModalType.EDIT_TENANT) {
-      const trimmedName = editName.trim();
-      if (!trimmedName) {
-        alert("Tenant name cannot be empty");
-        return;
+    if (type === TenantModalType.CREATE_TENANT) {
+      const trimmedRealmId = createRealmId.trim();
+      const trimmedDisplayName = createDisplayName.trim();
+      const realmIdError = validateTenantSlug(trimmedRealmId);
+      const displayNameError = validateDisplayName(trimmedDisplayName);
+      if (realmIdError) {
+        setCreateRealmIdError(realmIdError);
+        hasValidationError = true;
       }
+      if (displayNameError) {
+        setCreateDisplayNameError(displayNameError);
+        hasValidationError = true;
+      }
+    } else if (type === TenantModalType.EDIT_TENANT) {
+      if (!tenant) return;
+      const trimmedName = editName.trim();
+      const editError = validateDisplayName(trimmedName);
+      if (editError) {
+        setEditNameError(editError);
+        hasValidationError = true;
+      }
+    }
+
+    if (hasValidationError) {
+      return;
     }
 
     setLoading(true);
     try {
-      if (type === TenantModalType.EDIT_TENANT) {
+      if (type === TenantModalType.CREATE_TENANT) {
+        await TenantService.createTenant({
+          realm_id: createRealmId.trim(),
+          display_name: createDisplayName.trim(),
+        });
+      } else if (type === TenantModalType.EDIT_TENANT) {
+        if (!tenant) return;
         // TODO: Phase 2 - Only updating name for now. Status change will be added in Phase 2
         await TenantService.updateTenant(tenant.id, {
           name: editName.trim(),
@@ -79,18 +152,38 @@ export default function TenantModal({
       // else if (type === TenantModalType.DELETE_TENANT) {
       //   await TenantService.deleteTenant(tenant.id);
       // }
-      onSuccess();
+      onSuccess(
+        type === TenantModalType.CREATE_TENANT
+          ? "Tenant created successfully."
+          : "Tenant updated successfully.",
+      );
       onClose();
     } catch (err: any) {
-      const action = type === TenantModalType.EDIT_TENANT ? "update" : "delete";
-      alert(err.message || `Failed to ${action} tenant. Please try again.`);
+      const errorMessage = getErrorMessage(err);
+      if (
+        type === TenantModalType.CREATE_TENANT &&
+        errorMessage &&
+        (errorMessage.toLowerCase().includes("already exists") ||
+          errorMessage.toLowerCase().includes("conflict"))
+      ) {
+        setCreateRealmIdError("Tenant slug already exists");
+        return;
+      }
+      const action =
+        type === TenantModalType.CREATE_TENANT
+          ? "create"
+          : type === TenantModalType.EDIT_TENANT
+            ? "update"
+            : "delete";
+      setSubmitError(errorMessage || `Failed to ${action} tenant. Please try again.`);
     } finally {
       setLoading(false);
     }
   };
 
+  const isCreate = type === TenantModalType.CREATE_TENANT;
   const isDelete = type === TenantModalType.DELETE_TENANT;
-  const title = isDelete ? "Delete Tenant" : "Edit Tenant";
+  const title = isDelete ? "Delete Tenant" : isCreate ? "Add Tenant" : "Edit Tenant";
 
   return (
     <Dialog
@@ -136,14 +229,73 @@ export default function TenantModal({
           </Stack>
         ) : (
           <Stack spacing={3} sx={{ mt: 1 }}>
-            <TextField
-              label="Name"
-              fullWidth
-              value={editName}
-              onChange={(e) => setEditName(e.target.value)}
-              disabled={loading}
-              data-testid="tenant-name-input"
-            />
+            {submitError && (
+              <Alert severity="error" data-testid="tenant-modal-error">
+                {submitError}
+              </Alert>
+            )}
+            {isCreate ? (
+              <>
+                <TextField
+                  label="Realm Slug"
+                  fullWidth
+                  value={createRealmId}
+                  onChange={(e) => {
+                    setCreateRealmId(e.target.value);
+                    if (createRealmIdError) {
+                      setCreateRealmIdError("");
+                    }
+                    if (submitError) {
+                      setSubmitError("");
+                    }
+                  }}
+                  disabled={loading}
+                  error={Boolean(createRealmIdError)}
+                  helperText={createRealmIdError}
+                  inputProps={{ maxLength: MAX_SLUG_LENGTH }}
+                  data-testid="tenant-realm-id-input"
+                />
+                <TextField
+                  label="Display Name"
+                  fullWidth
+                  value={createDisplayName}
+                  onChange={(e) => {
+                    setCreateDisplayName(e.target.value);
+                    if (createDisplayNameError) {
+                      setCreateDisplayNameError("");
+                    }
+                    if (submitError) {
+                      setSubmitError("");
+                    }
+                  }}
+                  disabled={loading}
+                  error={Boolean(createDisplayNameError)}
+                  helperText={createDisplayNameError}
+                  inputProps={{ maxLength: MAX_DISPLAY_NAME_LENGTH }}
+                  data-testid="tenant-display-name-input"
+                />
+              </>
+            ) : (
+              <TextField
+                label="Name"
+                fullWidth
+                value={editName}
+                onChange={(e) => {
+                  setEditName(e.target.value);
+                  if (editNameError) {
+                    setEditNameError("");
+                  }
+                  if (submitError) {
+                    setSubmitError("");
+                  }
+                }}
+                disabled={loading}
+                error={Boolean(editNameError)}
+                helperText={editNameError}
+                inputProps={{ maxLength: MAX_DISPLAY_NAME_LENGTH }}
+                data-testid="tenant-name-input"
+              />
+            )}
             {/* TODO: Phase 2 - Status change functionality will be implemented in Phase 2 */}
             {/* <FormControl fullWidth>
               <InputLabel>Status</InputLabel>
@@ -180,7 +332,7 @@ export default function TenantModal({
           autoFocus={!isDelete}
           disabled={loading}
         >
-          {loading ? "Processing..." : isDelete ? "Delete" : "Save"}
+          {loading ? "Processing..." : isDelete ? "Delete" : isCreate ? "Create" : "Save"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/extensions/m8flow-frontend/src/views/TenantPage.test.tsx
+++ b/extensions/m8flow-frontend/src/views/TenantPage.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TenantPage from "./TenantPage";
+
+const mockUseTenants = vi.fn();
+const mockUsePermissionFetcher = vi.fn();
+const mockCreateTenant = vi.fn();
+
+vi.mock("../hooks/useTenants", () => ({
+  useTenants: () => mockUseTenants(),
+}));
+
+vi.mock("@spiffworkflow-frontend/hooks/PermissionService", () => ({
+  usePermissionFetcher: () => mockUsePermissionFetcher(),
+}));
+
+vi.mock("../services/TenantService", () => ({
+  default: {
+    createTenant: (...args: unknown[]) => mockCreateTenant(...args),
+    updateTenant: vi.fn(),
+    deleteTenant: vi.fn(),
+  },
+}));
+
+describe("TenantPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a tenant from the add tenant modal", async () => {
+    const refetch = vi.fn();
+    mockUseTenants.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch,
+    });
+    mockUsePermissionFetcher.mockReturnValue({
+      ability: { can: () => true },
+      permissionsLoaded: true,
+    });
+    mockCreateTenant.mockResolvedValue({
+      realm: "it",
+      displayName: "Information Technology",
+      keycloak_realm_id: "tenant-uuid",
+      id: "tenant-uuid",
+    });
+
+    render(<TenantPage />);
+
+    fireEvent.click(screen.getByTestId("tenant-add-button"));
+
+    fireEvent.change(screen.getByLabelText("Realm Slug"), {
+      target: { value: "it-team_1" },
+    });
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "Information Technology" },
+    });
+
+    fireEvent.click(screen.getByTestId("tenant-modal-submit-button"));
+
+    await waitFor(() => {
+      expect(mockCreateTenant).toHaveBeenCalledWith({
+        realm_id: "it-team_1",
+        display_name: "Information Technology",
+      });
+    });
+
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByText("Tenant created successfully.")).toBeInTheDocument();
+  });
+
+  it("shows inline validation errors instead of submitting an empty tenant form", async () => {
+    mockUseTenants.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUsePermissionFetcher.mockReturnValue({
+      ability: { can: () => true },
+      permissionsLoaded: true,
+    });
+
+    render(<TenantPage />);
+
+    fireEvent.click(screen.getByTestId("tenant-add-button"));
+    fireEvent.click(screen.getByTestId("tenant-modal-submit-button"));
+
+    expect(await screen.findByText("Tenant slug cannot be empty")).toBeInTheDocument();
+    expect(await screen.findByText("Tenant display name cannot be empty")).toBeInTheDocument();
+    expect(mockCreateTenant).not.toHaveBeenCalled();
+  });
+
+  it("validates slug format and display name length before submit", async () => {
+    mockUseTenants.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUsePermissionFetcher.mockReturnValue({
+      ability: { can: () => true },
+      permissionsLoaded: true,
+    });
+
+    render(<TenantPage />);
+
+    fireEvent.click(screen.getByTestId("tenant-add-button"));
+
+    fireEvent.change(screen.getByLabelText("Realm Slug"), {
+      target: { value: "it team" },
+    });
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "A".repeat(51) },
+    });
+
+    fireEvent.click(screen.getByTestId("tenant-modal-submit-button"));
+
+    expect(
+      await screen.findByText(
+        "Tenant slug can only contain letters, numbers, hyphens, and underscores",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Tenant display name must be 50 characters or fewer"),
+    ).toBeInTheDocument();
+    expect(mockCreateTenant).not.toHaveBeenCalled();
+  });
+
+  it("shows a slug validation error when the tenant slug already exists", async () => {
+    mockUseTenants.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUsePermissionFetcher.mockReturnValue({
+      ability: { can: () => true },
+      permissionsLoaded: true,
+    });
+    mockCreateTenant.mockRejectedValue({
+      detail: "Realm already exists or conflict",
+    });
+
+    render(<TenantPage />);
+
+    fireEvent.click(screen.getByTestId("tenant-add-button"));
+    fireEvent.change(screen.getByLabelText("Realm Slug"), {
+      target: { value: "it-team_1" },
+    });
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "Information Technology" },
+    });
+
+    fireEvent.click(screen.getByTestId("tenant-modal-submit-button"));
+
+    expect(await screen.findByText("Tenant slug already exists")).toBeInTheDocument();
+  });
+});

--- a/extensions/m8flow-frontend/src/views/TenantPage.tsx
+++ b/extensions/m8flow-frontend/src/views/TenantPage.tsx
@@ -22,13 +22,16 @@ import {
   Tooltip,
   CircularProgress,
   Alert,
+  Button,
+  Snackbar,
 } from "@mui/material";
 import {
   Search as SearchIcon,
   Edit as EditIcon,
-  Delete as DeleteIcon,
   Clear as ClearIcon,
+  Add as AddIcon,
 } from "@mui/icons-material";
+import { usePermissionFetcher } from "@spiffworkflow-frontend/hooks/PermissionService";
 import { Tenant } from "../services/TenantService";
 import { useTenants } from "../hooks/useTenants";
 import TenantModal from "./TenantModal";
@@ -45,12 +48,17 @@ type SortDirection = "asc" | "desc";
 type SearchType = "name" | "slug";
 
 export default function TenantPage() {
+  const { ability, permissionsLoaded } = usePermissionFetcher({
+    "/m8flow/tenant-realms": ["POST"],
+  });
   const {
     data: tenants = [],
     isLoading: loading,
     error: queryError,
     refetch,
   } = useTenants();
+  const canCreateTenant =
+    permissionsLoaded && ability.can("POST", "/m8flow/tenant-realms");
 
   // Search and filter states
   const [searchQuery, setSearchQuery] = useState("");
@@ -67,11 +75,18 @@ export default function TenantPage() {
     TenantModalType.EDIT_TENANT,
   );
   const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null);
+  const [successMessage, setSuccessMessage] = useState("");
 
   // Handle edit
   const handleEdit = (tenant: Tenant) => {
     setSelectedTenant(tenant);
     setModalType(TenantModalType.EDIT_TENANT);
+    setIsModalOpen(true);
+  };
+
+  const handleCreate = () => {
+    setSelectedTenant(null);
+    setModalType(TenantModalType.CREATE_TENANT);
     setIsModalOpen(true);
   };
 
@@ -87,7 +102,8 @@ export default function TenantPage() {
     setSelectedTenant(null);
   };
 
-  const handleModalSuccess = () => {
+  const handleModalSuccess = (message: string) => {
+    setSuccessMessage(message);
     refetch();
   };
 
@@ -173,6 +189,16 @@ export default function TenantPage() {
           >
             Tenant Management
           </Typography>
+          {canCreateTenant && (
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleCreate}
+              data-testid="tenant-add-button"
+            >
+              Add Tenant
+            </Button>
+          )}
         </Box>
 
         {/* Filters Section */}
@@ -396,6 +422,20 @@ export default function TenantPage() {
         onClose={handleCloseModal}
         onSuccess={handleModalSuccess}
       />
+      <Snackbar
+        open={Boolean(successMessage)}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMessage("")}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          severity="success"
+          onClose={() => setSuccessMessage("")}
+          sx={{ width: "100%" }}
+        >
+          {successMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }


### PR DESCRIPTION
## JIRA Ticket
https://aottech.atlassian.net/browse/M8F-199

## Description

Adds tenant creation to the Tenant Management UI using the existing POST /v1.0/m8flow/tenant-realms endpoint, and improves the tenant modal with inline validation.
<img width="1606" height="747" alt="image" src="https://github.com/user-attachments/assets/b82166d2-da37-4945-a103-21e9f0d43267" />


### Changes

- Added an Add Tenant button to the tenant management page.
- Gated the create action behind the POST /m8flow/tenant-realms permission.
- Added a new create mode to the tenant modal so users can create a tenant from the UI.
- Added frontend support for creating tenants via TenantService.createTenant(...).
- The create modal now collects:
  - realm_id as the tenant slug
  - display_name as the tenant name
- After a successful create, the tenant list is refreshed automatically.

#### Validation and UX improvements

- Replaced browser alert(...) popups with inline field validation and in-modal error messaging.
- Added slug validation for create:
  - required
  - max 15 characters
  - only letters, numbers, hyphens, and underscores
- Added display name validation for create:
  - required
  - max 50 characters
- Applied the same 50-character display name validation to edit tenant as well.
- Added input maxLength limits so the UI prevents overlong values while typing.

## Type

- [X] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [X] Frontend
- [ ] Documentation

## Testing
- Added/updated frontend test coverage for:
  - successful tenant creation from the modal
  - empty form validation
  - invalid slug format and overlong display name validation


## Related Issues

Closes #

