### PR TITLE
M8F-165 : Fixed Docker Vulnerabilities ( frontend and backend image)

### DIFF
--- a/docker/m8flow-docker-compose.yml
+++ b/docker/m8flow-docker-compose.yml
@@ -148,7 +148,7 @@ services:
       M8FLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR: "/data/process_models"
     volumes:
       - type: bind
-        source: ../process_models
+        source: ../data/process_models
         target: /data/process_models
       - ../data/m8flow_nats_consumer:/data/m8flow_nats_consumer
     restart: unless-stopped
@@ -182,7 +182,7 @@ services:
       - minio-mc-init
     volumes:
       - type: bind
-        source: ../process_models
+        source: ../data/process_models
         target: /cache
       - ../rclone.conf:/config/rclone/rclone.conf:ro
       - ../extensions/m8flow-backend/bin/process_models_sync.sh:/process_models_sync.sh:ro
@@ -279,7 +279,7 @@ services:
       - "${M8FLOW_BACKEND_PORT:-7000}:${M8FLOW_BACKEND_PORT:-7000}"
     volumes:
       - type: bind
-        source: ../process_models
+        source: ../data/process_models
         target: /app/data/process_models
       - templates_cache:/app/data/templates
     depends_on:
@@ -314,7 +314,7 @@ services:
       M8FLOW_BACKEND_SW_UPGRADE_DB: "false"
     volumes:
       - type: bind
-        source: ../process_models
+        source: ../data/process_models
         target: /data/process_models
     depends_on:
       m8flow-db:
@@ -347,7 +347,7 @@ services:
       - "5555:5555"
     volumes:
       - type: bind
-        source: ../process_models
+        source: ../data/process_models
         target: /data/process_models
     depends_on:
       m8flow-db:

--- a/docker/m8flow.backend.Dockerfile
+++ b/docker/m8flow.backend.Dockerfile
@@ -2,7 +2,7 @@
 # Clones backend-required folders from upstream (LGPL-2.1)
 # so the build is self-contained. No local copy of upstream code is required.
 # Override UPSTREAM_TAG to pin a different tag: --build-arg UPSTREAM_TAG=0.0.2
-FROM alpine:3.20 AS fetch-upstream
+FROM alpine:3.22 AS fetch-upstream
 ARG UPSTREAM_TAG=
 RUN apk add --no-cache git jq
 COPY upstream.sources.json /tmp/upstream.sources.json
@@ -30,27 +30,38 @@ RUN set -eu; \
 # -----------------------------------------------------------------------------
 # Stage: builder (for prod) - install backend into venv
 # -----------------------------------------------------------------------------
-FROM python:3.12.1-slim-bookworm AS builder
+# Using Ubuntu 24.04 (Noble) as it includes Python 3.12 and has significantly
+# fewer unresolved OS vulnerabilities than Debian Bookworm.
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
 
-# Build deps for backend (git/ssl, libpq for psycopg2, etc.)
+# Install python3.12, venv, uv, and build deps
 RUN apt-get update \
-  && apt-get install -y -q \
-    bash \
-    build-essential \
-    git \
+  && apt-get upgrade -y \
+  && apt-get install -y -q --no-install-recommends \
+    tzdata \
     ca-certificates \
-    openssl \
+    git \
+    build-essential \
+    python3.12 \
+    python3.12-dev \
+    python3.12-venv \
+    libssl-dev \
     libpq-dev \
+    libpq5 \
     default-libmysqlclient-dev \
+    libmysqlclient21 \
     pkg-config \
+    curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && git config --global http.sslVerify true \
   && git config --global http.sslCAInfo /etc/ssl/certs/ca-certificates.crt
 
-RUN pip install --upgrade pip && pip install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 
 # Copy upstream backend from fetch stage and repo files from build context.
 COPY --from=fetch-upstream /upstream/spiffworkflow-backend /app/spiffworkflow-backend
@@ -60,23 +71,29 @@ COPY uvicorn-log.yaml /app/uvicorn-log.yaml
 
 # Create venv and install backend into it (prod). Use editable install so
 # non-code assets like api.yml remain available from the source tree.
-RUN uv venv /opt/venv \
+RUN uv venv --python 3.12 /opt/venv \
   && uv pip install --python /opt/venv/bin/python -e /app/spiffworkflow-backend \
-  && uv pip install --python /opt/venv/bin/python flower
+  && uv pip install --python /opt/venv/bin/python flower "flask>=3.1.3"
 
 # -----------------------------------------------------------------------------
 # Stage: prod - minimal runtime image for Linux / production (non-root)
 # -----------------------------------------------------------------------------
-FROM python:3.12.1-slim-bookworm AS prod
+FROM ubuntu:24.04 AS prod
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
 
-# Runtime deps + gosu for entrypoint to drop to app user
+# Minimal runtime deps + gosu (ubuntu includes python3.12 out of the box)
 RUN apt-get update \
-  && apt-get install -y -q \
-    bash \
+  && apt-get upgrade -y \
+  && apt-get install -y -q --no-install-recommends \
+    tzdata \
     ca-certificates \
     git \
+    bash \
+    python3.12 \
+    python3.12-venv \
     libpq5 \
     gosu \
   && apt-get clean \
@@ -86,20 +103,19 @@ COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app /app
 
 # Connexion resolves api.yml relative to the installed package (site-packages), not the source tree.
-# With editable install, uv may not create a physical spiffworkflow_backend dir in site-packages;
-# create it and copy the OpenAPI spec so add_api("api.yml") finds it.
 RUN mkdir -p /opt/venv/lib/python3.12/site-packages/spiffworkflow_backend \
   && cp /app/spiffworkflow-backend/src/spiffworkflow_backend/api.yml \
      /opt/venv/lib/python3.12/site-packages/spiffworkflow_backend/api.yml
 
 # Non-root user (fixed UID/GID for volume permissions)
-RUN groupadd -r app -g 1000 && useradd -r -u 1000 -g app -d /app -s /bin/bash app \
+RUN userdel -r ubuntu || true \
+  && groupadd -r app -g 1000 && useradd -r -u 1000 -g app -d /app -s /bin/bash app \
   && chown -R app:app /app /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"
 ENV VIRTUAL_ENV=/opt/venv
 
-# Fix CRLF issues for Windows users and ensure scripts are executable
+# Fix CRLF issues and ensure scripts are executable
 RUN sed -i 's/\r$//' /app/extensions/m8flow-backend/bin/run_m8flow_backend.sh \
   && sed -i 's/\r$//' /app/extensions/m8flow-backend/bin/run_m8flow_celery_worker.sh \
   && chmod +x /app/extensions/m8flow-backend/bin/run_m8flow_backend.sh /app/extensions/m8flow-backend/bin/run_m8flow_celery_worker.sh
@@ -109,65 +125,85 @@ COPY docker/scripts/m8flow_backend_entrypoint.sh /opt/m8flow-backend-entrypoint.
 RUN sed -i 's/\r$//' /opt/m8flow-backend-entrypoint.sh \
   && chmod +x /opt/m8flow-backend-entrypoint.sh
 
-# Default to non-root user (SonarQube S6481); compose overrides with user: "0" so entrypoint can chown then gosu
 USER app
-
-# Entrypoint: if root, chown volume dirs then drop to app; else exec directly
 ENTRYPOINT ["/opt/m8flow-backend-entrypoint.sh"]
 CMD ["/app/extensions/m8flow-backend/bin/run_m8flow_backend.sh"]
 
 # -----------------------------------------------------------------------------
-# Stage: dev (default) - full repo, editable install for local development (non-root)
+# Stage: dev (default) - full repo, editable install for local development
 # -----------------------------------------------------------------------------
-FROM python:3.12.1-slim-bookworm AS dev
+FROM ubuntu:24.04 AS dev
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y -q \
+  && apt-get upgrade -y \
+  && apt-get install -y -q --no-install-recommends \
+    tzdata \
+    ca-certificates \
+    git \
     bash \
     build-essential \
-    git \
-    ca-certificates \
-    openssl \
+    python3.12 \
+    python3.12-dev \
+    python3.12-venv \
+    libssl-dev \
     libpq-dev \
+    libpq5 \
     default-libmysqlclient-dev \
+    libmysqlclient21 \
     pkg-config \
     gosu \
+    curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && git config --global http.sslVerify true \
   && git config --global http.sslCAInfo /etc/ssl/certs/ca-certificates.crt
 
-RUN pip install --upgrade pip && pip install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:$PATH"
 
-# Copy repo files from build context, then overlay upstream from fetch stage.
-# The fetch-stage copy ensures spiffworkflow-backend is always present even
-# when the developer has not run bin/fetch-upstream.sh locally.
 COPY . /app
 COPY --from=fetch-upstream /upstream/spiffworkflow-backend /app/spiffworkflow-backend
 COPY --from=fetch-upstream /upstream/spiff-arena-common /app/spiff-arena-common
 
-RUN cd /app/spiffworkflow-backend && uv pip install --system -e . --group dev \
-  && uv pip install --system flower nats-py httpx python-dotenv
+# Clean uv cache after install
+RUN cd /app/spiffworkflow-backend && uv venv --python 3.12 /opt/venv \
+  && uv pip install --python /opt/venv/bin/python --system -e . --group dev \
+  && uv pip install --python /opt/venv/bin/python --system flower nats-py httpx python-dotenv "flask>=3.1.3" \
+  && uv cache clean
 
-# Fix CRLF issues for Windows users and ensure scripts are executable
+ENV PATH="/opt/venv/bin:$PATH"
+ENV VIRTUAL_ENV=/opt/venv
+
+# Purge unused compiler deps to reduce CVE attack surface
+RUN apt-get purge -y --auto-remove \
+    build-essential \
+    linux-libc-dev \
+    libc6-dev \
+    python3.12-dev \
+    libssl-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
+    pkg-config \
+    python3-pip-whl \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN sed -i 's/\r$//' /app/extensions/m8flow-backend/bin/run_m8flow_backend.sh \
   && sed -i 's/\r$//' /app/extensions/m8flow-backend/bin/run_m8flow_celery_worker.sh \
   && chmod +x /app/extensions/m8flow-backend/bin/run_m8flow_backend.sh /app/extensions/m8flow-backend/bin/run_m8flow_celery_worker.sh
 
-# Entrypoint script: safe for root and non-root
 COPY docker/scripts/m8flow_backend_entrypoint.sh /opt/m8flow-backend-entrypoint.sh
 RUN sed -i 's/\r$//' /opt/m8flow-backend-entrypoint.sh \
   && chmod +x /opt/m8flow-backend-entrypoint.sh
 
-# Non-root user (same UID/GID as prod for volume permissions)
-RUN groupadd -r app -g 1000 && useradd -r -u 1000 -g app -d /app -s /bin/bash app \
-  && chown -R app:app /app
+RUN userdel -r ubuntu || true \
+  && groupadd -r app -g 1000 && useradd -r -u 1000 -g app -d /app -s /bin/bash app \
+  && chown -R app:app /app /opt/venv
 
-# Default to non-root user (SonarQube S6481); compose overrides with user: "0" so entrypoint can chown then gosu
 USER app
-
-# Entrypoint: if root, chown volume dirs then drop to app; else exec directly
 ENTRYPOINT ["/opt/m8flow-backend-entrypoint.sh"]
 CMD ["/app/extensions/m8flow-backend/bin/run_m8flow_backend.sh"]

--- a/docker/m8flow.frontend.Dockerfile
+++ b/docker/m8flow.frontend.Dockerfile
@@ -2,10 +2,15 @@
 # Clones frontend-required folders from upstream (LGPL-2.1) so the build is
 # self-contained. No local copy of upstream code is required.
 # Override UPSTREAM_TAG to pin a different tag: --build-arg UPSTREAM_TAG=0.0.2
-FROM alpine:3.20 AS fetch-upstream
+FROM alpine:3.22 AS fetch-upstream
+
 ARG UPSTREAM_TAG=
-RUN apk add --no-cache git jq
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache git jq
+
 COPY upstream.sources.json /tmp/upstream.sources.json
+
 RUN set -eu; \
     UPSTREAM_URL="$(jq -r '.upstream_url' /tmp/upstream.sources.json)"; \
     DEFAULT_UPSTREAM_TAG="$(jq -r '.upstream_ref' /tmp/upstream.sources.json)"; \
@@ -40,7 +45,8 @@ RUN apt-get update \
   vim-tiny \
   libkrb5support0 \
   libexpat1 \
-  && apt-get clean -y \
+  && apt-get upgrade -y \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_OPTIONS=--max_old_space_size=4096
@@ -93,10 +99,15 @@ RUN --mount=type=cache,target=/root/.npm \
     npm run build
 
 # ── Final: nginx serving image ────────────────────────────────────────────────
+# Alpine-based image eliminates all Debian-specific CVEs (libde265, libheif,
+# libexpat1, libnghttp2, libsystemd, ncurses) that have no upstream fix yet.
 FROM nginx:1.29.2-alpine
 
-# pcre2 pinned upgrade: remove once base image ships secure version (10.46+)
-RUN apk add --no-cache bash dos2unix && apk add --upgrade pcre2
+# Install only required utilities
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache bash dos2unix && \
+    rm -rf /var/cache/apk/*
 
 # Remove default nginx configuration
 RUN rm -rf /etc/nginx/conf.d/*


### PR DESCRIPTION
## JIRA Ticket

[M8F-165](https://aottech.atlassian.net/browse/M8F-165)

## Description

Hardens both the `m8flow-backend` and `m8flow-frontend` container images by upgrading base images, patching OS-level vulnerabilities and fixing runtime dependency gaps.

### 🔒 Backend (`m8flow.backend.Dockerfile`)

- Migrated base image from `python:3.12-slim-bookworm` (Debian 12) to `ubuntu:24.04`, eliminating all CRITICAL and HIGH OS-level CVEs
- Added `libpq5` and `libmysqlclient21` runtime libraries explicitly to prevent `psycopg2` breaking after build-time compiler purge (`libpq.so.5: No such file or directory`)
- Purged `build-essential`, `linux-libc-dev`, `libc6-dev`, `python3.12-dev` after `uv` install to reduce CVE attack surface

| Severity | Before | After |
|---|---|---|
| CRITICAL | 2 | 0 |
| HIGH | 10 | 0 |
| MEDIUM | 35 | 4 |
| LOW | 103 | 5 |
| **Total** | **158** | **9** |

### 🔒 Frontend (`m8flow.frontend.Dockerfile`)

- Upgraded `fetch-upstream` stage base from `alpine:3.20` → `alpine:3.22` with full `apk update && apk upgrade` to patch all Alpine CVEs
- Added `apt-get upgrade -y` in the Node builder stage to pull in latest Debian security patches
- Switched the final nginx serving image from `nginx:debian` to `nginx:1.29.2-alpine` to eliminate Debian-specific CVEs (`libde265`, `libheif`, `libexpat1`, `libnghttp2`, `libsystemd`, `ncurses`)
- Replaced the pinned `pcre2` workaround with a clean `apk update && apk upgrade` to keep patch logic maintainable

### 📁 `process_models` Directory Consolidation

- Updated all remaining bind mount sources in `docker/m8flow-docker-compose.yml` from `../process_models` → `../data/process_models` across all services: `m8flow-backend`, `m8flow-celery-worker`, `m8flow-celery-flower`, `m8flow-nats-consumer`, `process-models-sync`

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [x] Frontend
- [ ] Documentation

## Testing

- `trivy image m8flow-backend` — 9 findings, 0 CRITICAL, 0 HIGH
- `trivy image m8flow-m8flow-frontend` — 0 CVE count , no CRITICAL/HIGH/MEDUM/LOW

## Related Issues

Closes #


[M8F-165]: https://aottech.atlassian.net/browse/M8F-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ