### PR TITLE
Fixed keycloak docker vulnerabilities

### DIFF
--- a/docker/m8flow.keycloak.Dockerfile
+++ b/docker/m8flow.keycloak.Dockerfile
@@ -13,9 +13,11 @@ COPY keycloak-extensions/realm-info-mapper /build/realm-info-mapper
 RUN mvn -f /build/realm-info-mapper/pom.xml clean package -q -DskipTests
 
 # Keycloak with provider JAR (no host mount).
-FROM quay.io/keycloak/keycloak:26.0.8
+FROM quay.io/keycloak/keycloak:26.6.1
 COPY --from=builder /build/realm-info-mapper/target/realm-info-mapper.jar /opt/keycloak/providers/realm-info-mapper.jar
 USER root
+# Keycloak 26 uses UBI Micro which ships without any package manager.
+# OS-level security patches should be obtained by pulling the latest Keycloak image.
 RUN mkdir -p /opt/keycloak/data/import
 COPY extensions/m8flow-backend/keycloak/realm_exports/m8flow-tenant-template.json /opt/keycloak/data/import/m8flow-tenant-template.json
 RUN chown -R keycloak:keycloak /opt/keycloak/data/import


### PR DESCRIPTION
## JIRA Ticket

[M8F-221](https://aot-technologies.atlassian.net/browse/M8F-221)

## Description

- **Base Image Upgrade:** Migrated the Keycloak service to version **26.6.1**. This upgrade includes the latest security patches from the Keycloak team and moves the service to the **UBI 9 Micro** base.
- **Micro Base Security:** Keycloak 26 uses a "distroless-like" UBI Micro image which contains only the essential dependencies to run the JVM and Keycloak. By removing shell utilities and package managers (`dnf`/`microdnf`), we have significantly reduced the attack surface for potential exploits.
- **Documentation for Maintainability:** Added explicit documentation to the Dockerfile regarding the UBI Micro limitations. This ensures that future security maintenance follows the correct pattern of upgrading the base image rather than attempting to inject package managers, which would expand the container's vulnerability profile.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [x] Other (Security/Build)

## Changes

- [x] Backend
- [ ] Frontend
- [x] Documentation (Dockerfile notes)

## Testing
sucessfully builded the image

## Related Issues

Closes #M8F-221


[M8F-221]: https://aottech.atlassian.net/browse/M8F-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ