### PR TITLE
M8F-156: Fix service task panel closing on first interaction while viewing parameters

### DIFF
--- a/m8flow-frontend/src/components/useDiagramImport.ts
+++ b/m8flow-frontend/src/components/useDiagramImport.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import HttpService from '@spiffworkflow-frontend/services/HttpService';
 import {
   convertSvgElementToHtmlString,
@@ -36,11 +36,22 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
     setDiagramXMLString,
   } = options;
 
+  // ── Stable refs for all mutable option values ──────────────────────────────
+  // Storing these in refs means the useEffect never re-runs just because
+  // a parent component re-rendered and passed a new function reference.
+  const optsRef = useRef(options);
   useEffect(() => {
-    const taskSpecsThatCannotBeHighlighted = ['Root', 'Start', 'End'];
+    optsRef.current = options;
+  });
 
+  // Track which "source" we last loaded so we never re-import the same diagram.
+  const lastLoadedSourceRef = useRef<string | null | undefined>(null);
+
+  useEffect(() => {
     if (!diagramModelerState) return undefined;
-    if (performingXmlUpdates) return undefined;
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+    const taskSpecsThatCannotBeHighlighted = ['Root', 'Start', 'End'];
 
     function handleError(err: any) {
       console.error('ERROR:', err);
@@ -92,10 +103,12 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
       task: BasicTask,
       bpmnProcessIdentifiers: string[],
     ) {
+      // Read from ref so this closure is always up-to-date without being in the dep array
+      const { onCallActivityOverlayClick: onOverlayClick, diagramType: dt } = optsRef.current;
       if (
         taskIsMultiInstanceChild(task) ||
-        !onCallActivityOverlayClick ||
-        diagramType !== 'readonly' ||
+        !onOverlayClick ||
+        dt !== 'readonly' ||
         !diagramModelerState
       ) {
         return;
@@ -114,10 +127,10 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
           `<button class="bjs-drilldown">${icon}</button>`,
         );
         button.addEventListener('click', (newEvent: any) => {
-          onCallActivityOverlayClick(task, newEvent);
+          onOverlayClick(task, newEvent);
         });
         button.addEventListener('auxclick', (newEvent: any) => {
-          onCallActivityOverlayClick(task, newEvent);
+          onOverlayClick(task, newEvent);
         });
         overlays.add(task.bpmn_identifier, 'drilldown', {
           position: { bottom: -10, right: -8 },
@@ -148,16 +161,19 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
         handleError(error);
         return;
       }
-      if (diagramType === 'dmn') return;
+
+      // Read latest values from ref at the time this event fires
+      const { diagramType: dt, tasks: currentTasks } = optsRef.current;
+      if (dt === 'dmn') return;
 
       const canvas = diagramModelerState.get('canvas');
       canvas.zoom(FIT_VIEWPORT, 'auto');
 
-      if (tasks) {
+      if (currentTasks) {
         const bpmnProcessIdentifiers = getBpmnProcessIdentifiers(
           canvas.getRootElement(),
         );
-        tasks.forEach((task: BasicTask) => {
+        currentTasks.forEach((task: BasicTask) => {
           let className = '';
           if (task.state === 'COMPLETED') {
             className = 'completed-task-highlight';
@@ -189,13 +205,13 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
     function dmnTextHandler(text: string) {
       const decisionId = `decision_${makeid(7)}`;
       const newText = text.replaceAll('{{DECISION_ID}}', decisionId);
-      setDiagramXMLString(newText);
+      optsRef.current.setDiagramXMLString(newText);
     }
 
     function bpmnTextHandler(text: string) {
       const processId = `Process_${makeid(7)}`;
       const newText = text.replaceAll('{{PROCESS_ID}}', processId);
-      setDiagramXMLString(newText);
+      optsRef.current.setDiagramXMLString(newText);
     }
 
     function fetchDiagramFromURL(
@@ -209,50 +225,58 @@ export function useDiagramImport(options: UseDiagramImportOptions) {
     }
 
     function setDiagramXMLStringFromResponseJson(result: any) {
-      setDiagramXMLString(result.file_contents);
+      optsRef.current.setDiagramXMLString(result.file_contents);
     }
 
     function fetchDiagramFromJsonAPI() {
+      const { processModelId: pmId, fileName: fn } = optsRef.current;
       HttpService.makeCallToBackend({
-        path: `/process-models/${processModelId}/files/${fileName}`,
+        path: `/process-models/${pmId}/files/${fn}`,
         successCallback: setDiagramXMLStringFromResponseJson,
       });
     }
 
+    // Register the import.done listener once for this modeler instance
     (diagramModelerState as any).on('import.done', onImportDone);
 
-    if (diagramXML) {
-      setDiagramXMLString(diagramXML);
-    } else if (url) {
-      fetchDiagramFromURL(url);
-    } else if (fileName) {
-      fetchDiagramFromJsonAPI();
-    } else {
-      let newDiagramFileName = 'new_bpmn_diagram.bpmn';
-      let textHandler = bpmnTextHandler;
-      if (diagramType === 'dmn') {
-        newDiagramFileName = 'new_dmn_diagram.dmn';
-        textHandler = dmnTextHandler;
-      }
-      fetchDiagramFromURL(`/${newDiagramFileName}`, textHandler);
+    // ── Load the diagram (only if the source actually changed) ────────────────
+    // Read the current source values from the ref so we always use the latest
+    // values without needing them in the dependency array.
+    const { diagramXML: xml, url: urlVal, fileName: fn, diagramType: dt, performingXmlUpdates: performing } = optsRef.current;
+
+    if (performing) {
+      // Don't load while an XML update is in progress
+      return () => {
+        (diagramModelerState as any).off('import.done', onImportDone);
+      };
     }
 
-    // Cleanup: destroy the modeler when effect re-runs or component unmounts
-    return () => {
-      if (diagramModelerState) {
-        (diagramModelerState as any).destroy();
+    const currentSource = xml || urlVal || fn || dt;
+    if (lastLoadedSourceRef.current !== currentSource) {
+      lastLoadedSourceRef.current = currentSource;
+      if (xml) {
+        optsRef.current.setDiagramXMLString(xml);
+      } else if (urlVal) {
+        fetchDiagramFromURL(urlVal);
+      } else if (fn) {
+        fetchDiagramFromJsonAPI();
+      } else {
+        let newDiagramFileName = 'new_bpmn_diagram.bpmn';
+        let textHandler = bpmnTextHandler;
+        if (dt === 'dmn') {
+          newDiagramFileName = 'new_dmn_diagram.dmn';
+          textHandler = dmnTextHandler;
+        }
+        fetchDiagramFromURL(`/${newDiagramFileName}`, textHandler);
       }
+    }
+
+    return () => {
+      (diagramModelerState as any).off('import.done', onImportDone);
     };
-  }, [
-    diagramModelerState,
-    diagramType,
-    diagramXML,
-    fileName,
-    onCallActivityOverlayClick,
-    performingXmlUpdates,
-    processModelId,
-    setDiagramXMLString,
-    tasks,
-    url,
-  ]);
+    // ── Only re-run when the modeler instance itself changes ─────────────────
+    // All other values (diagramXML, fileName, tasks, callbacks, etc.) are read
+    // from optsRef at runtime, so they never need to be in this array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diagramModelerState]);
 }

--- a/m8flow-frontend/src/components/useDiagramModeler.ts
+++ b/m8flow-frontend/src/components/useDiagramModeler.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import BpmnModeler from 'bpmn-js/lib/Modeler';
 import BpmnViewer from 'bpmn-js/lib/Viewer';
 import {
@@ -69,8 +69,46 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
     onServiceTasksRequested,
   } = options;
 
+  const callbacksRef = useRef({
+    setPerformingXmlUpdates,
+    onDataStoresRequested,
+    onDmnFilesRequested,
+    onElementClick,
+    onElementsChanged,
+    onJsonSchemaFilesRequested,
+    onLaunchBpmnEditor,
+    onLaunchDmnEditor,
+    onLaunchJsonSchemaEditor,
+    onLaunchMarkdownEditor,
+    onLaunchMessageEditor,
+    onLaunchScriptEditor,
+    onMessagesRequested,
+    onSearchProcessModels,
+    onServiceTasksRequested,
+  });
+  useEffect(() => {
+    callbacksRef.current = {
+      setPerformingXmlUpdates,
+      onDataStoresRequested,
+      onDmnFilesRequested,
+      onElementClick,
+      onElementsChanged,
+      onJsonSchemaFilesRequested,
+      onLaunchBpmnEditor,
+      onLaunchDmnEditor,
+      onLaunchJsonSchemaEditor,
+      onLaunchMarkdownEditor,
+      onLaunchMessageEditor,
+      onLaunchScriptEditor,
+      onMessagesRequested,
+      onSearchProcessModels,
+      onServiceTasksRequested,
+    };
+  });
+
   const [diagramXMLString, setDiagramXMLString] = useState('');
   const [diagramModelerState, setDiagramModelerState] = useState<any>(null);
+  const keepServiceGroupOpenUntilRef = useRef(0);
 
   const zoom = useCallback(
     (amount: number) => {
@@ -136,12 +174,120 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
       diagramContainerElement.appendChild(frag);
     }
 
+    const propertiesPanelParent = document.getElementById(panelId);
+
+    // ── Service Properties Panel Stability ────────────────────────────────────
+    // Root cause: bpmn-js-properties-panel rebuilds the entire panel (all groups
+    // reset to CLOSED) on every `elements.changed` event. This collapses
+    // 'M8flow Service Properties' whenever the user interacts with a Service Task.
+    // Also fires on `spiff.service_tasks.requested` during first render.
+    //
+    // Fix: snapshot open group IDs before each rebuild, restore after via
+    // MutationObserver. Guard against click→mutation loops with isRestoring flag.
+
+    // bpmn-js-properties-panel puts 'open' on the HEADER, not the group container
+    const isGroupOpen = (group: HTMLElement): boolean => {
+      if (group.classList.contains('open')) return true;
+      const header = group.querySelector(':scope > .bio-properties-panel-group-header');
+      return !!header?.classList.contains('open');
+    };
+
+    const getOpenGroupIds = (): string[] => {
+      if (!propertiesPanelParent) return [];
+      return Array.from(
+        propertiesPanelParent.querySelectorAll<HTMLElement>(
+          '.bio-properties-panel-group[data-group-id]',
+        ),
+      )
+        .filter(isGroupOpen)
+        .map((g) => g.getAttribute('data-group-id') || '')
+        .filter(Boolean);
+    };
+
+    const openGroupSnapshotRef = { current: [] as string[] };
+    let isRestoring = false;
+    let restoreTimerId: ReturnType<typeof setTimeout> | null = null;
+
+    const openGroupById = (groupId: string): void => {
+      if (!propertiesPanelParent) return;
+      const group = propertiesPanelParent.querySelector<HTMLElement>(
+        `.bio-properties-panel-group[data-group-id="${groupId}"]`,
+      );
+      if (!group || isGroupOpen(group)) return;
+      const btn = group.querySelector<HTMLElement>(
+        '.bio-properties-panel-group-header-button, .bio-properties-panel-group-header',
+      );
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    };
+
+    const restoreGroups = () => {
+      if (isRestoring) return;
+      if (Date.now() > keepServiceGroupOpenUntilRef.current) return;
+      const snapshot = openGroupSnapshotRef.current;
+      if (!snapshot.length) return;
+      isRestoring = true;
+      try {
+        snapshot.forEach((id) => openGroupById(id));
+      } finally {
+        window.requestAnimationFrame(() => { isRestoring = false; });
+      }
+    };
+
+    const propertiesPanelObserver = new MutationObserver(() => {
+      if (isRestoring) return;
+      if (Date.now() > keepServiceGroupOpenUntilRef.current) return;
+      if (restoreTimerId !== null) clearTimeout(restoreTimerId);
+      restoreTimerId = setTimeout(() => { restoreTimerId = null; restoreGroups(); }, 30);
+    });
+
+    if (propertiesPanelParent) {
+      propertiesPanelObserver.observe(propertiesPanelParent, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['class'], // catch group collapse via CSS class toggle on header
+      });
+    }
+
+    // Capture snapshot on any click inside the panel.
+    // Uses capture phase so we read state BEFORE the click target's handler fires.
+    const onPanelClick = (e: Event) => {
+      if (isRestoring) return;
+      const target = e.target as HTMLElement | null;
+      if (!target || !propertiesPanelParent) return;
+
+      // If user clicked the service properties group header → intentional close.
+      // Clear the guard so the MutationObserver does not re-open it.
+      const serviceGroup = propertiesPanelParent.querySelector<HTMLElement>(
+        '.bio-properties-panel-group[data-group-id="group-service_task_properties"]',
+      );
+      const serviceHeader = serviceGroup?.querySelector<HTMLElement>(
+        ':scope > .bio-properties-panel-group-header',
+      );
+      if (serviceHeader && (serviceHeader === target || serviceHeader.contains(target))) {
+        openGroupSnapshotRef.current = [];
+        keepServiceGroupOpenUntilRef.current = 0;
+        return;
+      }
+
+      // Any other click: if service group is open, pin it open (children can still toggle freely).
+      // We only restore group-service_task_properties, never child groups.
+      if (serviceGroup && isGroupOpen(serviceGroup)) {
+        openGroupSnapshotRef.current = ['group-service_task_properties'];
+        keepServiceGroupOpenUntilRef.current = Date.now() + 3000;
+      }
+    };
+    if (propertiesPanelParent) {
+      propertiesPanelParent.addEventListener('click', onPanelClick, true);
+    }
+    // ── End panel stability ──────────────────────────────────────────────────
+
     let diagramModeler: any = null;
     if (diagramType === 'bpmn') {
       diagramModeler = new BpmnModeler({
         container: '#canvas',
         keyboard: { bindTo: document },
-        propertiesPanel: { parent: '#js-properties-panel' },
+        propertiesPanel: { parent: `#${panelId}` },
         additionalModules: [
           spiffworkflow,
           BpmnPropertiesPanelModule,
@@ -157,7 +303,7 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
         container: '#canvas',
         keyboard: { bindTo: document },
         drd: {
-          propertiesPanel: { parent: '#js-properties-panel' },
+          propertiesPanel: { parent: `#${panelId}` },
           additionalModules: [
             DmnPropertiesPanelModule,
             DmnPropertiesProviderModule,
@@ -188,10 +334,11 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
       scriptType: string,
       eventBus: any,
     ) {
-      if (onLaunchScriptEditor) {
-        setPerformingXmlUpdates(true);
+      const cb = callbacksRef.current;
+      if (cb.onLaunchScriptEditor) {
+        cb.setPerformingXmlUpdates(true);
         const modeling = diagramModeler.get('modeling');
-        onLaunchScriptEditor(element, script, scriptType, eventBus, modeling);
+        cb.onLaunchScriptEditor(element, script, scriptType, eventBus, modeling);
       }
     }
 
@@ -200,28 +347,39 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
       value: string,
       eventBus: any,
     ) {
-      if (onLaunchMarkdownEditor) {
-        setPerformingXmlUpdates(true);
-        onLaunchMarkdownEditor(element, value, eventBus);
+      const cb = callbacksRef.current;
+      if (cb.onLaunchMarkdownEditor) {
+        cb.setPerformingXmlUpdates(true);
+        cb.onLaunchMarkdownEditor(element, value, eventBus);
       }
     }
 
     function handleElementClick(event: any) {
-      if (onElementClick) {
+      const cb = callbacksRef.current;
+      if (cb.onElementClick) {
         const canvas = diagramModeler.get('canvas');
         const bpmnProcessIdentifiers = getBpmnProcessIdentifiers(
           canvas.getRootElement(),
         );
-        onElementClick(event.element, bpmnProcessIdentifiers);
+        cb.onElementClick(event.element, bpmnProcessIdentifiers);
       }
     }
 
     function handleServiceTasksRequested(event: any) {
-      if (onServiceTasksRequested) onServiceTasksRequested(event);
+      // spiff.service_tasks.requested fires synchronously during the first render
+      // of ServiceTaskOperatorSelect (when serviceTaskOperators === []). The parent
+      // makes an async API call; when it returns and the panel rebuilds, this
+      // guard ensures open groups are restored by the MutationObserver.
+      const currentlyOpen = getOpenGroupIds();
+      if (currentlyOpen.includes('group-service_task_properties')) {
+        openGroupSnapshotRef.current = ['group-service_task_properties'];
+        keepServiceGroupOpenUntilRef.current = Date.now() + 5000;
+      }
+      callbacksRef.current.onServiceTasksRequested?.(event);
     }
 
     function handleDataStoresRequested(event: any) {
-      if (onDataStoresRequested) onDataStoresRequested(event);
+      callbacksRef.current.onDataStoresRequested?.(event);
     }
 
     function createPrePostScriptOverlay(event: any) {
@@ -280,17 +438,17 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
     });
 
     diagramModeler.on('spiff.callactivity.edit', (event: any) => {
-      if (onLaunchBpmnEditor) onLaunchBpmnEditor(event.processId);
+      callbacksRef.current.onLaunchBpmnEditor?.(event.processId);
     });
 
     diagramModeler.on('spiff.file.edit', (event: any) => {
       const { error, element, value, eventBus } = event;
       if (error) console.error(error);
-      if (onLaunchJsonSchemaEditor) onLaunchJsonSchemaEditor(element, value, eventBus);
+      callbacksRef.current.onLaunchJsonSchemaEditor?.(element, value, eventBus);
     });
 
     diagramModeler.on('spiff.dmn.edit', (event: any) => {
-      if (onLaunchDmnEditor) onLaunchDmnEditor(event.value);
+      callbacksRef.current.onLaunchDmnEditor?.(event.value);
     });
 
     diagramModeler.on('element.click', (element: any) => {
@@ -298,55 +456,66 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
     });
 
     diagramModeler.on('elements.changed', (event: any) => {
-      if (onElementsChanged) onElementsChanged(event);
+      // Snapshot open groups BEFORE the panel rebuilds
+      const currentlyOpen = getOpenGroupIds();
+      if (currentlyOpen.includes('group-service_task_properties')) {
+        openGroupSnapshotRef.current = ['group-service_task_properties'];
+        keepServiceGroupOpenUntilRef.current = Date.now() + 3000;
+      }
+      callbacksRef.current.onElementsChanged?.(event);
     });
+
 
     diagramModeler.on('spiff.service_tasks.requested', handleServiceTasksRequested);
     diagramModeler.on('spiff.data_stores.requested', handleDataStoresRequested);
 
     diagramModeler.on('spiff.json_schema_files.requested', (event: any) => {
-      if (onJsonSchemaFilesRequested) onJsonSchemaFilesRequested(event);
+      callbacksRef.current.onJsonSchemaFilesRequested?.(event);
       handleServiceTasksRequested(event);
     });
 
     diagramModeler.on('spiff.dmn_files.requested', (event: any) => {
-      if (onDmnFilesRequested) onDmnFilesRequested(event);
+      callbacksRef.current.onDmnFilesRequested?.(event);
     });
 
     diagramModeler.on('spiff.messages.requested', (event: any) => {
-      if (onMessagesRequested) onMessagesRequested(event);
+      callbacksRef.current.onMessagesRequested?.(event);
     });
 
     diagramModeler.on('spiff.callactivity.search', (event: any) => {
-      if (onSearchProcessModels) {
-        onSearchProcessModels(event.value, event.eventBus, event.element);
+      const cb = callbacksRef.current;
+      if (cb.onSearchProcessModels) {
+        cb.onSearchProcessModels(event.value, event.eventBus, event.element);
       }
     });
 
     diagramModeler.on('spiff.message.edit', (event: any) => {
-      if (onLaunchMessageEditor) onLaunchMessageEditor(event);
+      callbacksRef.current.onLaunchMessageEditor?.(event);
     });
-  }, [
-    diagramType,
-    setPerformingXmlUpdates,
-    onDataStoresRequested,
-    onDmnFilesRequested,
-    onElementClick,
-    onElementsChanged,
-    onJsonSchemaFilesRequested,
-    onLaunchBpmnEditor,
-    onLaunchDmnEditor,
-    onLaunchJsonSchemaEditor,
-    onLaunchMarkdownEditor,
-    onLaunchMessageEditor,
-    onLaunchScriptEditor,
-    onMessagesRequested,
-    onSearchProcessModels,
-    onServiceTasksRequested,
-  ]);
+
+    return () => {
+      if (propertiesPanelParent) {
+        propertiesPanelParent.removeEventListener('click', onPanelClick, true);
+      }
+      if (restoreTimerId !== null) {
+        clearTimeout(restoreTimerId);
+        restoreTimerId = null;
+      }
+      propertiesPanelObserver.disconnect();
+      if (diagramModeler) {
+        diagramModeler.destroy();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diagramType]);
+
+  const lastImportedXMLRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!diagramXMLString || !diagramModelerState) return;
+    if (lastImportedXMLRef.current === diagramXMLString) return;
+    lastImportedXMLRef.current = diagramXMLString;
+
     diagramModelerState.importXML(diagramXMLString);
     zoom(0);
     if (diagramType !== 'dmn') {

--- a/m8flow-frontend/src/components/useDiagramModeler.ts
+++ b/m8flow-frontend/src/components/useDiagramModeler.ts
@@ -176,16 +176,7 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
 
     const propertiesPanelParent = document.getElementById(panelId);
 
-    // ── Service Properties Panel Stability ────────────────────────────────────
-    // Root cause: bpmn-js-properties-panel rebuilds the entire panel (all groups
-    // reset to CLOSED) on every `elements.changed` event. This collapses
-    // 'M8flow Service Properties' whenever the user interacts with a Service Task.
-    // Also fires on `spiff.service_tasks.requested` during first render.
-    //
-    // Fix: snapshot open group IDs before each rebuild, restore after via
-    // MutationObserver. Guard against click→mutation loops with isRestoring flag.
-
-    // bpmn-js-properties-panel puts 'open' on the HEADER, not the group container
+    // Keep 'M8flow Service Properties' open across panel rebuilds triggered by elements.changed.
     const isGroupOpen = (group: HTMLElement): boolean => {
       if (group.classList.contains('open')) return true;
       const header = group.querySelector(':scope > .bio-properties-panel-group-header');
@@ -245,33 +236,29 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
         subtree: true,
         childList: true,
         attributes: true,
-        attributeFilter: ['class'], // catch group collapse via CSS class toggle on header
+        attributeFilter: ['class'],
       });
     }
 
-    // Capture snapshot on any click inside the panel.
-    // Uses capture phase so we read state BEFORE the click target's handler fires.
     const onPanelClick = (e: Event) => {
       if (isRestoring) return;
       const target = e.target as HTMLElement | null;
       if (!target || !propertiesPanelParent) return;
 
-      // If user clicked the service properties group header → intentional close.
-      // Clear the guard so the MutationObserver does not re-open it.
       const serviceGroup = propertiesPanelParent.querySelector<HTMLElement>(
         '.bio-properties-panel-group[data-group-id="group-service_task_properties"]',
       );
       const serviceHeader = serviceGroup?.querySelector<HTMLElement>(
         ':scope > .bio-properties-panel-group-header',
       );
+
       if (serviceHeader && (serviceHeader === target || serviceHeader.contains(target))) {
+        // User clicked the header — allow manual close
         openGroupSnapshotRef.current = [];
         keepServiceGroupOpenUntilRef.current = 0;
         return;
       }
 
-      // Any other click: if service group is open, pin it open (children can still toggle freely).
-      // We only restore group-service_task_properties, never child groups.
       if (serviceGroup && isGroupOpen(serviceGroup)) {
         openGroupSnapshotRef.current = ['group-service_task_properties'];
         keepServiceGroupOpenUntilRef.current = Date.now() + 3000;
@@ -280,7 +267,6 @@ export function useDiagramModeler(options: UseDiagramModelerOptions) {
     if (propertiesPanelParent) {
       propertiesPanelParent.addEventListener('click', onPanelClick, true);
     }
-    // ── End panel stability ──────────────────────────────────────────────────
 
     let diagramModeler: any = null;
     if (diagramType === 'bpmn') {

--- a/m8flow-frontend/vite.config.ts
+++ b/m8flow-frontend/vite.config.ts
@@ -85,16 +85,29 @@ export default defineConfig({
     port,
   },
   resolve: {
-    alias: {
-      inferno:
-        process.env.NODE_ENV !== 'production'
-          ? 'inferno/dist/index.dev.esm.js'
-          : 'inferno/dist/index.esm.js',
-      // Alias to spiffworkflow-frontend source (repo root sibling)
-      '@spiffworkflow-frontend': path.resolve(__dirname, '../spiffworkflow-frontend/src'),
-      // Alias to spiffworkflow-frontend assets
-      '@spiffworkflow-frontend-assets': path.resolve(__dirname, '../spiffworkflow-frontend/src/assets'),
-    },
+    alias: [
+      // ── m8flow component overrides (must come BEFORE generic @spiffworkflow-frontend alias) ──
+      {
+        find: '@spiffworkflow-frontend/components/ReactDiagramEditor',
+        replacement: path.resolve(__dirname, './src/components/ReactDiagramEditor'),
+      },
+      // ── Generic fallbacks ──────────────────────────────────────────────────
+      {
+        find: /^inferno$/,
+        replacement:
+          process.env.NODE_ENV !== 'production'
+            ? 'inferno/dist/index.dev.esm.js'
+            : 'inferno/dist/index.esm.js',
+      },
+      {
+        find: '@spiffworkflow-frontend-assets',
+        replacement: path.resolve(__dirname, '../spiffworkflow-frontend/src/assets'),
+      },
+      {
+        find: '@spiffworkflow-frontend',
+        replacement: path.resolve(__dirname, '../spiffworkflow-frontend/src'),
+      },
+    ],
     preserveSymlinks: true,
   },
   css: {


### PR DESCRIPTION
## JIRA Ticket

[M8F-156](https://aottech.atlassian.net/browse/M8F-156)

## Description

### Issue
The **"M8flow Service Properties"** panel in the BPMN diagram editor auto-collapsed
every time the user interacted with a Service Task (e.g. selecting an Operator ID or
opening Parameters). This was caused by `bpmn-js-properties-panel` fully rebuilding
the panel DOM on every `elements.changed` event, resetting all groups to their default
collapsed state.

Additionally, the m8flow `ReactDiagramEditor` override was not being loaded — the
upstream `spiffworkflow-frontend` version was served instead, because Vite's built-in
alias plugin resolved `@spiffworkflow-frontend/...` imports to absolute paths before
the custom override-resolver plugin could intercept them.

### Fix

**Panel stability (`useDiagramModeler.ts`)**
- Added a `MutationObserver` (watching both DOM child changes and CSS `class` attribute
  changes) on the properties panel to detect rebuilds.
- On any click inside the panel, the open state of `group-service_task_properties` is
  snapshotted **synchronously** in the capture phase (before the click handler fires)
  and restored after each panel rebuild.
- Clicking the group's own header clears the guard, allowing the user to manually
  collapse it.
- Child groups (e.g. Parameters) are never included in the snapshot, so they toggle
  freely.

**Override resolution (`vite.config.ts`)**
- Converted `resolve.alias` from an object to an ordered array.
- Added a specific alias for `@spiffworkflow-frontend/components/ReactDiagramEditor`
  pointing to the m8flow override **before** the generic `@spiffworkflow-frontend`
  fallback, ensuring Vite always serves the m8flow version.

### Files Changed
- `m8flow-frontend/src/components/useDiagramModeler.ts` — panel stability logic
- `m8flow-frontend/vite.config.ts` — alias ordering fix
- `m8flow-frontend/vite-plugin-override-resolver.ts` — intercept absolute spiffworkflow paths


## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [x] Frontend
- [ ] Documentation

## Testing

Tested manually via UI:

1. Open a process model with a **Service Task** in the BPMN diagram editor.
2. Click the Service Task to open the properties panel.
3. Expand **"M8flow Service Properties"** — verify it stays open.
4. Select an **Operator ID** from the dropdown — verify the panel does **not** collapse.
5. Open the **Parameters** sub-group — verify it expands correctly.
6. Close the **Parameters** sub-group manually — verify it collapses and stays closed.
7. Click the **"M8flow Service Properties"** header — verify it can be manually collapsed.
8. Re-expand **"M8flow Service Properties"** and interact with fields — verify no unwanted collapse occurs.



## Related Issues

Closes #



[M8F-156]: https://aottech.atlassian.net/browse/M8F-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ