### PR TITLE
M8F-220: Add event-based process start from external form submissions

### DIFF
--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -1083,7 +1083,7 @@ paths:
           description: The NATS stream name to publish the event to.
 
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
@@ -1411,8 +1411,7 @@ components:
 
     M8flowTriggerRequest:
       type: object
-      required:
-        - data
+
       properties:
         data:
           description: >

--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -1034,6 +1034,92 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /events/m8flow-trigger:
+    post:
+      summary: Receive an external trigger event
+      description: >
+        Public webhook endpoint that accepts an external trigger payload, publishes
+        a NATS event, and synchronously waits for the process instance to be created.
+        Returns the created process instance details. The caller must supply a valid
+        tenant API key (generated via POST /api/nats-tokens) in the X-M8FLOW-NATS-API-Key header.
+        No Keycloak JWT is required.
+      operationId: m8flow_backend.routes.events_controller.m8flow_trigger
+      tags:
+        - Events
+      security: []
+      parameters:
+        - name: X-M8FLOW-NATS-API-Key
+          in: header
+          required: true
+          schema:
+            type: string
+          description: >
+            A valid tenant API key obtained from POST /api/nats-tokens.
+            The key is validated via HMAC-SHA256 against the stored hash.
+
+        - name: X-M8FLOW-Process-Identifier
+          in: header
+          required: true
+          schema:
+            type: string
+          description: The identifier of the process to trigger.
+        - name: X-M8FLOW-Username
+          in: header
+          required: true
+          schema:
+            type: string
+          description: The username on whose behalf the process is triggered.
+        - name: X-M8FLOW-Tenant-Slug
+          in: header
+          required: true
+          schema:
+            type: string
+          description: The human-readable slug of the tenant.
+        - name: X-M8FLOW-Stream-Name
+          in: header
+          required: true
+          schema:
+            type: string
+          description: The NATS stream name to publish the event to.
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/M8flowTriggerRequest"
+      responses:
+        "200":
+          description: Event accepted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/M8flowTriggerResponse"
+        "400":
+          description: Bad request – missing or malformed body / missing tenant context
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized – X-M8FLOW-API-Key header is absent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden – X-M8FLOW-API-Key is invalid or revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   schemas:
     HealthResponse:
@@ -1310,3 +1396,34 @@ components:
           type: integer
         modifiedBy:
           type: string
+
+    M8flowTriggerRequest:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          description: >
+            Arbitrary caller-supplied payload. Can be any JSON value
+            (object, array, string, number, or boolean).
+
+    M8flowTriggerResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: "Event received."
+        tenant_id:
+          type: string
+          description: Resolved tenant identifier for the request
+        process_identifier:
+          type: string
+          description: The process identifier from the request header
+        username:
+          type: string
+          description: The username from the request header
+        data:
+          description: Echo of the data field from the request body

--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -1090,7 +1090,13 @@ paths:
               $ref: "#/components/schemas/M8flowTriggerRequest"
       responses:
         "200":
-          description: Event accepted successfully
+          description: Event accepted and process instance created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/M8flowTriggerResponse"
+        "202":
+          description: Event published to NATS but no reply received from the consumer within the timeout window. The process instance may still be created asynchronously.
           content:
             application/json:
               schema:
@@ -1113,6 +1119,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: Event was published and the consumer processed it, but process instance creation failed due to a validation or process model error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/M8flowTriggerResponse"
         "500":
           description: Internal server error
           content:
@@ -1406,6 +1418,13 @@ components:
           description: >
             Arbitrary caller-supplied payload. Can be any JSON value
             (object, array, string, number, or boolean).
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: array
+            - type: string
+            - type: number
+            - type: boolean
 
     M8flowTriggerResponse:
       type: object
@@ -1416,14 +1435,31 @@ components:
         message:
           type: string
           example: "Event received."
-        tenant_id:
-          type: string
-          description: Resolved tenant identifier for the request
-        process_identifier:
-          type: string
-          description: The process identifier from the request header
-        username:
-          type: string
-          description: The username from the request header
         data:
-          description: Echo of the data field from the request body
+          type: object
+          description: Detailed response data including tenant context, event echo, and process instance details
+          properties:
+            tenant_id:
+              type: string
+              description: Resolved tenant identifier for the request
+            tenant_slug:
+              type: string
+              description: Tenant slug from the request header
+            process_identifier:
+              type: string
+              description: The process identifier from the request header
+            username:
+              type: string
+              description: The username from the request header
+            event:
+              type: object
+              additionalProperties: true
+              description: Echo of the published event data (excluding internal fields)
+            error:
+              type: string
+              description: Error message if process instance creation failed (present on 422 responses)
+            process_instance:
+              description: Process instance details if created successfully, null otherwise
+              type: object
+              additionalProperties: true
+              nullable: true

--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -1108,13 +1108,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "401":
-          description: Unauthorized – X-M8FLOW-API-Key header is absent
+          description: Unauthorized – X-M8FLOW-NATS-API-Key header is absent
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "403":
-          description: Forbidden – X-M8FLOW-API-Key is invalid or revoked
+          description: Forbidden – X-M8FLOW-NATS-API-Key is invalid or revoked
           content:
             application/json:
               schema:

--- a/m8flow-backend/src/m8flow_backend/config.py
+++ b/m8flow-backend/src/m8flow_backend/config.py
@@ -134,3 +134,8 @@ def redirect_uri_frontend_host() -> str | None:
 def nats_token_salt() -> str:
     """Get the NATS token salt from environment variables."""
     return _get("M8FLOW_NATS_TOKEN_SALT") or "m8flow_default_salt"
+
+
+def nats_url() -> str:
+    """Get the NATS URL from environment variables."""
+    return _get("M8FLOW_NATS_URL") or "nats://admin:admin@nats:4222"

--- a/m8flow-backend/src/m8flow_backend/config.py
+++ b/m8flow-backend/src/m8flow_backend/config.py
@@ -133,7 +133,7 @@ def redirect_uri_frontend_host() -> str | None:
 
 def nats_token_salt() -> str:
     """Get the NATS token salt from environment variables."""
-    return _get("M8FLOW_NATS_TOKEN_SALT")
+    return _get("M8FLOW_NATS_TOKEN_SALT") or "m8flow_default_salt"
 
 
 def nats_url() -> str:

--- a/m8flow-backend/src/m8flow_backend/config.py
+++ b/m8flow-backend/src/m8flow_backend/config.py
@@ -133,9 +133,9 @@ def redirect_uri_frontend_host() -> str | None:
 
 def nats_token_salt() -> str:
     """Get the NATS token salt from environment variables."""
-    return _get("M8FLOW_NATS_TOKEN_SALT") or "m8flow_default_salt"
+    return _get("M8FLOW_NATS_TOKEN_SALT")
 
 
 def nats_url() -> str:
     """Get the NATS URL from environment variables."""
-    return _get("M8FLOW_NATS_URL") or "nats://admin:admin@nats:4222"
+    return _get("M8FLOW_NATS_URL")

--- a/m8flow-backend/src/m8flow_backend/models/nats_token.py
+++ b/m8flow-backend/src/m8flow_backend/models/nats_token.py
@@ -2,21 +2,22 @@ from __future__ import annotations
 from dataclasses import dataclass
 from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel, db
 from m8flow_backend.models.audit_mixin import AuditDateTimeMixin
-from m8flow_backend.models.tenant_scoped import M8fTenantScopedMixin, TenantScoped
 
 @dataclass
-class NatsTokenModel(M8fTenantScopedMixin, TenantScoped, SpiffworkflowBaseDBModel, AuditDateTimeMixin):
+class NatsTokenModel(SpiffworkflowBaseDBModel, AuditDateTimeMixin):
     """SQLAlchemy model for NATS tokens."""
     __tablename__ = "m8flow_nats_tokens"
 
     m8f_tenant_id: str = db.Column(
         db.String(255),
         db.ForeignKey("m8flow_tenant.id"),
-        primary_key=True
+        primary_key=True,
+        nullable=False,
+        index=True
     )
     token: str = db.Column(db.String(255), nullable=False, unique=True)
     created_by: str = db.Column(db.String(255), nullable=False)
     modified_by: str = db.Column(db.String(255), nullable=False)
 
-    def __repr__(self):
-        return f"<NatsTokenModel(tenant_id={self.m8f_tenant_id}, token={self.token})>"
+    def __repr__(self) -> str:
+        return f"<NatsTokenModel(tenant_id={self.m8f_tenant_id})>"

--- a/m8flow-backend/src/m8flow_backend/routes/events_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/events_controller.py
@@ -95,13 +95,6 @@ def m8flow_trigger() -> tuple:
     body = request.get_json(silent=True) or {}
     data = body.get("data")
 
-    if data is None:
-        raise ApiError(
-            error_code="missing_data_field",
-            message="Request body must be JSON with a top-level 'data' field.",
-            status_code=400,
-        )
-
     # We use the provided_stream_name from the header for the NATS publish as requested.
     try:
         event_data = NatsService.publish_event(

--- a/m8flow-backend/src/m8flow_backend/routes/events_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/events_controller.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import logging
+
+from flask import request
+from spiffworkflow_backend.exceptions.api_error import ApiError
+
+from m8flow_backend.helpers.response_helper import handle_api_errors, success_response
+
+from m8flow_backend.services.nats_token_service import NatsTokenService
+
+from m8flow_backend.services.nats_service import NatsService
+from m8flow_backend.services.tenant_service import TenantService
+
+logger = logging.getLogger("m8flow.events.controller")
+
+
+def _resolve_tenant_and_validate_key() -> tuple[str, str, str]:
+    """
+    1. Extract X-M8FLOW-Tenant-Slug and X-M8FLOW-NATS-API-Key from headers.
+    2. Resolve the slug to a tenant UUID via TenantService.
+    3. Verify the API key against that tenant using NatsTokenService.verify_token.
+    Returns (tenant_id, tenant_slug, api_key) on success; raises ApiError on failure.
+    """
+    tenant_slug = request.headers.get("X-M8FLOW-Tenant-Slug")
+    api_key = request.headers.get("X-M8FLOW-NATS-API-Key")
+
+    if not tenant_slug:
+        logger.warning("m8flow-trigger: missing tenant slug header")
+        raise ApiError(
+            error_code="missing_tenant_slug",
+            message="Required header X-M8FLOW-Tenant-Slug is missing.",
+            status_code=400,
+        )
+
+    if not api_key:
+        logger.warning("m8flow-trigger: missing API key header")
+        raise ApiError(
+            error_code="missing_api_key",
+            message="Required header X-M8FLOW-NATS-API-Key is missing.",
+            status_code=401,
+        )
+
+    # Step 1: Resolve slug → tenant UUID (TenantService handles 404 if not found)
+    tenant = TenantService.get_tenant_by_slug(tenant_slug)
+    tenant_id = tenant.id
+
+    # Step 2: Verify the API key against the resolved tenant
+    if not NatsTokenService.verify_token(tenant_id, api_key):
+        logger.warning("m8flow-trigger: invalid API key for tenant slug=%s", tenant_slug)
+        raise ApiError(
+            error_code="invalid_api_key",
+            message="The provided X-M8FLOW-NATS-API-Key is invalid for this tenant.",
+            status_code=403,
+        )
+
+    return tenant_id, tenant_slug, api_key
+
+
+@handle_api_errors
+def m8flow_trigger() -> tuple:
+    """
+    POST /api/events/m8flow-trigger
+
+    Receive an external trigger event, publish to NATS, and acknowledge.
+
+    Required headers
+    ----------------
+    X-M8FLOW-NATS-API-Key : str
+        A valid tenant API key generated via POST /api/nats-tokens.
+    X-M8FLOW-Process-Identifier : str
+        The identifier of the process to trigger.
+    X-M8FLOW-Username : str
+        The username on whose behalf the process is triggered.
+
+    Request body (JSON)
+    -------------------
+    {
+        "data": { ... }   # arbitrary caller-supplied payload
+    }
+    """
+    tenant_id, tenant_slug, api_key = _resolve_tenant_and_validate_key()
+
+    process_identifier = request.headers.get("X-M8FLOW-Process-Identifier")
+    username = request.headers.get("X-M8FLOW-Username")
+    provided_stream_name = request.headers.get("X-M8FLOW-Stream-Name")
+
+    if not all([process_identifier, username, provided_stream_name]):
+        raise ApiError(
+            error_code="missing_required_headers",
+            message="Required headers X-M8FLOW-Process-Identifier, X-M8FLOW-Username, and X-M8FLOW-Stream-Name are missing.",
+            status_code=400,
+        )
+
+    body = request.get_json(silent=True) or {}
+    data = body.get("data")
+
+    if data is None:
+        raise ApiError(
+            error_code="missing_data_field",
+            message="Request body must be JSON with a top-level 'data' field.",
+            status_code=400,
+        )
+
+    # We use the provided_stream_name from the header for the NATS publish as requested.
+    try:
+        event_data = NatsService.publish_event(
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            process_identifier=process_identifier,
+            username=username,
+            payload=data,
+            api_key=api_key,
+            stream_name=provided_stream_name
+        )
+
+    except Exception as e:
+        raise ApiError(
+            error_code="nats_publish_failed",
+            message=f"Failed to publish event to NATS: {str(e)}",
+            status_code=500
+        )
+
+    # Pop internal fields so they don't show up in the event echo
+    event_data.pop("api_key", None)
+    event_data.pop("reply_to", None)
+    event_data.pop("tenant_id", None)
+    event_data.pop("tenant_slug", None)
+    event_data.pop("username", None)
+    
+    # Process instance is returned separately
+    process_instance_details = event_data.pop("process_instance", None)
+
+    return success_response(
+        {
+            "ok": True,
+            "message": "Event received and published.",
+            "data": {
+                "tenant_id": tenant_id,
+                "tenant_slug": tenant_slug,
+                "process_identifier": process_identifier,
+                "username": username,
+                "event": event_data,
+                "process_instance": process_instance_details,
+            },
+        },
+        200,
+    )
+
+
+

--- a/m8flow-backend/src/m8flow_backend/routes/events_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/events_controller.py
@@ -131,10 +131,46 @@ def m8flow_trigger() -> tuple:
     # Process instance is returned separately
     process_instance_details = event_data.pop("process_instance", None)
 
+    # Check if the consumer replied with an error
+    if isinstance(process_instance_details, dict) and process_instance_details.get("error"):
+        return success_response(
+            {
+                "ok": False,
+                "message": "Event published but process instance creation failed.",
+                "data": {
+                    "tenant_id": tenant_id,
+                    "tenant_slug": tenant_slug,
+                    "process_identifier": process_identifier,
+                    "username": username,
+                    "event": event_data,
+                    "error": process_instance_details.get("message", "Unknown error"),
+                    "process_instance": None,
+                },
+            },
+            422,
+        )
+
+    if process_instance_details is None:
+        return success_response(
+            {
+                "ok": False,
+                "message": "Event published but no response from consumer (timeout).",
+                "data": {
+                    "tenant_id": tenant_id,
+                    "tenant_slug": tenant_slug,
+                    "process_identifier": process_identifier,
+                    "username": username,
+                    "event": event_data,
+                    "process_instance": None,
+                },
+            },
+            202,
+        )
+
     return success_response(
         {
             "ok": True,
-            "message": "Event received and published.",
+            "message": "Event received and process instance created.",
             "data": {
                 "tenant_id": tenant_id,
                 "tenant_slug": tenant_slug,

--- a/m8flow-backend/src/m8flow_backend/services/authorization_service_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/authorization_service_patch.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 M8FLOW_AUTH_EXCLUSION_ADDITIONS = [
     "m8flow_backend.routes.keycloak_controller.get_tenant_login_url",
     "m8flow_backend.tenancy.health_check",
+    "m8flow_backend.routes.events_controller.m8flow_trigger",
 ]
+
 M8FLOW_ROLE_GROUP_IDENTIFIERS = frozenset(
     {"super-admin", "tenant-admin", "editor", "viewer", "integrator", "reviewer"}
 )

--- a/m8flow-backend/src/m8flow_backend/services/nats_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/nats_service.py
@@ -6,6 +6,7 @@ import uuid
 from nats.aio.client import Client as NATS
 from nats.js.errors import NotFoundError
 from m8flow_backend.config import nats_url
+from spiffworkflow_backend.exceptions.api_error import ApiError
 
 logger = logging.getLogger("m8flow.nats.service")
 

--- a/m8flow-backend/src/m8flow_backend/services/nats_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/nats_service.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+import asyncio
+import json
+import logging
+import uuid
+from nats.aio.client import Client as NATS
+from nats.js.errors import NotFoundError
+from m8flow_backend.config import nats_url
+
+logger = logging.getLogger("m8flow.nats.service")
+
+class NatsService:
+    @staticmethod
+    async def _publish(
+        tenant_id: str,
+        tenant_slug: str,
+        process_identifier: str,
+        username: str,
+        payload: dict,
+        api_key: str,
+        stream_name: str | None = None,
+        reply_timeout: float = 30.0,
+    ) -> dict:
+        nc = NATS()
+        try:
+            await nc.connect(nats_url(), connect_timeout=5)
+        except Exception as e:
+            logger.error("nats_service: failed to connect to NATS at %s: %s", nats_url(), str(e))
+            raise ApiError(
+                error_code="nats_connection_error",
+                message=f"Could not connect to NATS server: {str(e)}",
+                status_code=503
+            )
+
+        js = nc.jetstream()
+        subject = f"m8flow.events.{tenant_slug}.trigger"
+        event_id = str(uuid.uuid4())
+
+        # Create a unique inbox subject for the consumer to reply to
+        reply_to = f"_INBOX.m8flow.{event_id}"
+        reply_future: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        # Subscribe to the inbox before publishing so we don't miss the reply
+        async def _on_reply(msg: any) -> None:
+            if not reply_future.done():
+                reply_future.set_result(msg.data)
+
+        inbox_sub = await nc.subscribe(reply_to, cb=_on_reply)
+
+        event_data = {
+            "id": event_id,
+            "subject": subject,
+            "tenant_id": tenant_id,
+            "tenant_slug": tenant_slug,
+            "process_identifier": process_identifier,
+            "username": username,
+            "payload": payload,
+            "api_key": api_key,
+            "reply_to": reply_to,
+        }
+
+        try:
+            ack = await js.publish(
+                subject,
+                json.dumps(event_data).encode("utf-8"),
+                headers={
+                    "Nats-Msg-Id": event_id,
+                    "tenant_slug": tenant_slug,
+                    "stream_name": stream_name,
+                },
+            )
+            logger.info("Published to NATS: subject=%s stream=%s seq=%s", subject, ack.stream, ack.seq)
+
+            # Wait for the consumer to reply with process instance details
+            try:
+                raw_reply = await asyncio.wait_for(reply_future, timeout=reply_timeout)
+                instance_details = json.loads(raw_reply.decode("utf-8"))
+                logger.info("Received process instance reply for event_id=%s", event_id)
+            except asyncio.TimeoutError:
+                logger.warning("No reply received within %ss for event_id=%s", reply_timeout, event_id)
+                instance_details = None
+
+            return {**event_data, "process_instance": instance_details}
+
+        except NotFoundError:
+            logger.error("Stream '%s' does not exist.", stream_name)
+            raise
+        except Exception as e:
+            logger.error("NATS publish failed: %s", e)
+            raise
+        finally:
+            await inbox_sub.unsubscribe()
+            await nc.close()
+
+
+
+
+    @staticmethod
+    def publish_event(
+        tenant_id: str,
+        tenant_slug: str,
+        process_identifier: str,
+        username: str,
+        payload: dict,
+        api_key: str,
+        stream_name: str | None = None
+    ) -> dict:
+        """Synchronous wrapper to publish event to NATS."""
+        coro = NatsService._publish(
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            process_identifier=process_identifier,
+            username=username,
+            payload=payload,
+            api_key=api_key,
+            stream_name=stream_name
+        )
+
+        
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop is running, we can use asyncio.run
+            return asyncio.run(coro)
+        
+        # If a loop is already running (e.g. in uvicorn), we can't use asyncio.run
+        # We use a Future to wait for the result from the coroutine
+        if loop.is_running():
+            # This is tricky in a synchronous Flask handler. 
+            # However, if we are in an ASGI environment, we might actually be in a sync thread worker.
+            # For now, let's try to run it in a new thread or use a loop runner.
+            from concurrent.futures import ThreadPoolExecutor
+            with ThreadPoolExecutor() as executor:
+                return executor.submit(asyncio.run, coro).result()
+        
+        return loop.run_until_complete(coro)
+

--- a/m8flow-backend/src/m8flow_backend/services/nats_token_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/nats_token_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import secrets
-import string
 from m8flow_backend.models.nats_token import NatsTokenModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.exceptions.api_error import ApiError
@@ -8,6 +7,7 @@ from m8flow_backend.config import nats_token_salt
 
 import hashlib
 import hmac
+import logging
 
 class NatsTokenService:
     @staticmethod
@@ -76,16 +76,4 @@ class NatsTokenService:
         salt = nats_token_salt()
         expected_hash = NatsTokenService._hash_token(raw_token, salt)
 
-        logger.debug(
-            "verify_token: stored=%s expected=%s match=%s",
-            nats_token.token[:12] + "...",
-            expected_hash[:12] + "...",
-            nats_token.token == expected_hash,
-        )
-
         return hmac.compare_digest(nats_token.token, expected_hash)
-
-    @staticmethod
-    def get_token_for_tenant(tenant_id: str) -> NatsTokenModel | None:
-        """Retrieve the hashed NATS token record for a specific tenant."""
-        return NatsTokenModel.query.filter_by(m8f_tenant_id=tenant_id).first()

--- a/m8flow-nats-consumer/consumer.py
+++ b/m8flow-nats-consumer/consumer.py
@@ -68,17 +68,16 @@ def instantiate_process(
             # and the tenant-membership filter in one step.
             user = resolve_user_for_current_tenant(username, tenant_id=tenant_id)
             if user is None:
-                logger.error(
-                    f"User '{username}' not found in the database for tenant '{tenant_id}'. "
-                    "Ensure the username matches the preferred_username stored in Keycloak. Event discarded."
-                )
-                return None
+                err = f"User '{username}' not found in the database for tenant '{tenant_id}'."
+                logger.error(err)
+                raise ValueError(err)
 
             try:
                 process_model = ProcessModelService.get_process_model(process_identifier)
             except Exception as e:
-                logger.error(f"Process model '{process_identifier}' not found: {e}")
-                return None
+                err = f"Process model '{process_identifier}' not found: {e}"
+                logger.error(err)
+                raise ValueError(err)
 
             data_to_inject = {**payload, "_nats_initiator_username": username}
 
@@ -137,89 +136,75 @@ def _extract_tenant_from_subject(subject: str) -> str | None:
 async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
     """Authenticate and process a single NATS event."""
     from spiffworkflow_backend.exceptions.api_error import ApiError
-    try:
-        data = json.loads(msg.data.decode("utf-8"))
-
-    except Exception as e:
-        logger.error("Failed to parse message data: %s", e)
-        await msg.ack()
-        return
-
-    # Authoritative tenant_id comes from the NATS subject, not the payload
-    subject_tenant_id = _extract_tenant_from_subject(msg.subject)
-    if not subject_tenant_id:
-        logger.error("Event subject has unexpected format — cannot determine tenant. Discarding. subject=%s", msg.subject)
-        await msg.ack()
-        return
-
-    # The NATS subject carries the slug for routing (e.g. m8flow.events.zoro.trigger).
-    # The payload carries the tenant UUID for auth and process instantiation.
-    # Use the UUID from the payload as the authoritative tenant_id.
-    payload_tenant_id = data.get("tenant_id")
-    payload_tenant_slug = data.get("tenant_slug")
-
-    if not payload_tenant_id:
-        logger.error("Event payload missing 'tenant_id' (UUID). Discarding. subject=%s", msg.subject)
-        await msg.ack()
-        return
-
-    # Optional: validate that the slug in the subject matches what the publisher sent
-    if payload_tenant_slug and payload_tenant_slug != subject_tenant_id:
-        logger.error(
-            "Tenant slug mismatch: subject slug '%s' != payload slug '%s'. Event discarded.",
-            subject_tenant_id, payload_tenant_slug,
-        )
-        await msg.ack()
-        return
-
-    tenant_id = payload_tenant_id  # UUID
-
-    process_identifier = data.get("process_identifier")
-    username           = data.get("username")
-    event_id           = data.get("id")
-    api_key            = data.get("api_key")
-
-    if not all([process_identifier, username]):
-        logger.error(
-            "Message missing required fields (process_identifier, username). "
-            "Discarding."
-        )
-        await msg.ack()
-        return
-
-    if not api_key:
-        logger.error("Rejecting event: 'api_key' is missing. tenant=%s", tenant_id)
-        await msg.ack()
-        return
-
-    def _verify():
-        from m8flow_backend.services.nats_token_service import NatsTokenService
-        from m8flow_backend.tenancy import set_context_tenant_id, reset_context_tenant_id
-        with flask_app.app_context():
-            token = set_context_tenant_id(tenant_id)
-            try:
-                return NatsTokenService.verify_token(tenant_id, api_key)
-            finally:
-                reset_context_tenant_id(token)
-
-    is_valid = await asyncio.to_thread(_verify)
-
-    if not is_valid:
-        logger.error("Rejecting event: Invalid api_key for tenant %s", tenant_id)
-        await msg.ack()
-        return
-
+    
+    data = {}
+    reply_to = None
     dedup_key = None
-    if event_id and tenant_id:
-        dedup_key = await check_idempotency(kv, tenant_id, event_id)
-        if dedup_key is None:
+    tenant_id = None
+    process_identifier = None
+
+    try:
+        try:
+            data = json.loads(msg.data.decode("utf-8"))
+            reply_to = data.get("reply_to")
+        except Exception as e:
+            logger.error("Failed to parse message data: %s", e)
             await msg.ack()
             return
-    else:
-        if not event_id:
-            logger.warning("Event has no 'id' field — idempotency cannot be guaranteed.")
 
-    try:
+        # Authoritative tenant_id comes from the NATS subject, not the payload
+        subject_tenant_id = _extract_tenant_from_subject(msg.subject)
+        if not subject_tenant_id:
+            raise ValueError(f"Event subject has unexpected format — cannot determine tenant: {msg.subject}")
+
+        # The NATS subject carries the slug for routing (e.g. m8flow.events.zoro.trigger).
+        # The payload carries the tenant UUID for auth and process instantiation.
+        payload_tenant_id = data.get("tenant_id")
+        payload_tenant_slug = data.get("tenant_slug")
+
+        if not payload_tenant_id:
+            raise ValueError("Event payload missing 'tenant_id' (UUID).")
+
+        # Optional: validate that the slug in the subject matches what the publisher sent
+        if payload_tenant_slug and payload_tenant_slug != subject_tenant_id:
+            raise ValueError(f"Tenant slug mismatch: subject slug '{subject_tenant_id}' != payload slug '{payload_tenant_slug}'")
+
+        tenant_id = payload_tenant_id  # UUID
+        process_identifier = data.get("process_identifier")
+        username           = data.get("username")
+        event_id           = data.get("id")
+        api_key            = data.get("api_key")
+
+        if not all([process_identifier, username]):
+            raise ValueError("Message missing required fields (process_identifier, username).")
+
+        if not api_key:
+            raise ValueError(f"Rejecting event: 'api_key' is missing for tenant {tenant_id}")
+
+        def _verify():
+            from m8flow_backend.services.nats_token_service import NatsTokenService
+            from m8flow_backend.tenancy import set_context_tenant_id, reset_context_tenant_id
+            with flask_app.app_context():
+                token = set_context_tenant_id(tenant_id)
+                try:
+                    return NatsTokenService.verify_token(tenant_id, api_key)
+                finally:
+                    reset_context_tenant_id(token)
+
+        is_valid = await asyncio.to_thread(_verify)
+        if not is_valid:
+            raise ValueError(f"Rejecting event: Invalid api_key for tenant {tenant_id}")
+
+        if event_id and tenant_id:
+            dedup_key = await check_idempotency(kv, tenant_id, event_id)
+            if dedup_key is None:
+                # Duplicate event, already logged in check_idempotency
+                await msg.ack()
+                return
+        else:
+            if not event_id:
+                logger.warning("Event has no 'id' field — idempotency cannot be guaranteed.")
+
         instance_id = await asyncio.to_thread(
             instantiate_process,
             tenant_id,
@@ -228,16 +213,6 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
             data.get("payload", {}),
         )
 
-        if instance_id is None:
-            logger.warning("Event processing aborted: pre-condition not met (see errors above).")
-            if dedup_key and kv:
-                try:
-                    await kv.delete(dedup_key)
-                except Exception:
-                    pass
-            await msg.ack()
-            return
-
         logger.info(
             "Process instance created | tenant=%s identifier=%s instance_id=%s",
             tenant_id, process_identifier, instance_id.get("id"),
@@ -245,23 +220,21 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
         await msg.ack()
 
         # Reply to the publisher with process instance details
-        reply_to = data.get("reply_to")
-        if reply_to and instance_id:
+        if reply_to:
             try:
                 await nc.publish(reply_to, json.dumps(instance_id).encode("utf-8"))
-
             except Exception as e:
                 logger.warning("Failed to send reply to %s: %s", reply_to, e)
 
-    except (ApiError, ValueError, TypeError) as e:
-        # Permanent business-logic failure (e.g. missing lane users, invalid BPMN config,
-        # workflow script validation errors like missing required fields).
-        # NAKing would cause endless retries since the data won't change — ACK to discard.
+    except Exception as e:
+        # Most failures are PERMANENT (validation, missing models, auth).
+        # We ACK to discard the message and stop the infinite retry loop.
+        error_msg = str(e)
         logger.error(
-            "Process instantiation failed (permanent error, discarding message): "
-            "tenant=%s identifier=%s error=%s",
-            tenant_id, process_identifier, e,
+            "Event processing failed (ACKing message): tenant=%s identifier=%s error=%s type=%s",
+            tenant_id, process_identifier, error_msg, type(e).__name__,
         )
+        
         if dedup_key and kv:
             try:
                 await kv.delete(dedup_key)
@@ -269,23 +242,14 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
                 pass
 
         # Reply with error details so the API can return a meaningful response
-        reply_to = data.get("reply_to")
         if reply_to:
             try:
-                error_reply = {"error": True, "message": str(e)}
+                error_reply = {"error": True, "message": error_msg}
                 await nc.publish(reply_to, json.dumps(error_reply).encode("utf-8"))
-            except Exception:
-                pass
+            except Exception as publish_err:
+                logger.warning("Failed to send error reply to %s: %s", reply_to, publish_err)
 
         await msg.ack()
-    except Exception as e:
-        logger.error("Process instantiation failed (transient error, will retry): %s", e)
-        if dedup_key and kv:
-            try:
-                await kv.delete(dedup_key)
-            except Exception:
-                pass
-        await msg.nak(delay=RETRY_DELAY)
 
 async def main() -> None:
     global flask_app

--- a/m8flow-nats-consumer/consumer.py
+++ b/m8flow-nats-consumer/consumer.py
@@ -88,8 +88,16 @@ def instantiate_process(
                 data_to_inject=data_to_inject,
                 user=user,
             )
+            instance = processor.process_instance_model
             db.session.commit()
-            return processor.process_instance_model.id
+            return {
+                "id": instance.id,
+                "status": instance.status,
+                "process_model_identifier": instance.process_model_identifier,
+                "created_at_in_seconds": instance.created_at_in_seconds,
+                "updated_at_in_seconds": instance.updated_at_in_seconds,
+            }
+
         except Exception:
             db.session.rollback()
             raise
@@ -126,12 +134,12 @@ def _extract_tenant_from_subject(subject: str) -> str | None:
     return None
 
 
-async def process_message(msg: Any, kv: KeyValue | None) -> None:
+async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
     """Authenticate and process a single NATS event."""
     from spiffworkflow_backend.exceptions.api_error import ApiError
     try:
         data = json.loads(msg.data.decode("utf-8"))
-        logger.debug("Received event: %s", data)
+
     except Exception as e:
         logger.error("Failed to parse message data: %s", e)
         await msg.ack()
@@ -144,16 +152,28 @@ async def process_message(msg: Any, kv: KeyValue | None) -> None:
         await msg.ack()
         return
 
-    # If the payload also carries a tenant_id, it must match the subject
-    payload_tenant_id  = data.get("tenant_id")
-    if payload_tenant_id and payload_tenant_id != subject_tenant_id:
+    # The NATS subject carries the slug for routing (e.g. m8flow.events.zoro.trigger).
+    # The payload carries the tenant UUID for auth and process instantiation.
+    # Use the UUID from the payload as the authoritative tenant_id.
+    payload_tenant_id = data.get("tenant_id")
+    payload_tenant_slug = data.get("tenant_slug")
+
+    if not payload_tenant_id:
+        logger.error("Event payload missing 'tenant_id' (UUID). Discarding. subject=%s", msg.subject)
+        await msg.ack()
+        return
+
+    # Optional: validate that the slug in the subject matches what the publisher sent
+    if payload_tenant_slug and payload_tenant_slug != subject_tenant_id:
         logger.error(
-            "Tenant mismatch: payload tenant does not match subject tenant. Event discarded."
+            "Tenant slug mismatch: subject slug '%s' != payload slug '%s'. Event discarded.",
+            subject_tenant_id, payload_tenant_slug,
         )
         await msg.ack()
         return
 
-    tenant_id          = subject_tenant_id
+    tenant_id = payload_tenant_id  # UUID
+
     process_identifier = data.get("process_identifier")
     username           = data.get("username")
     event_id           = data.get("id")
@@ -220,9 +240,19 @@ async def process_message(msg: Any, kv: KeyValue | None) -> None:
 
         logger.info(
             "Process instance created | tenant=%s identifier=%s instance_id=%s",
-            tenant_id, process_identifier, instance_id,
+            tenant_id, process_identifier, instance_id.get("id"),
         )
         await msg.ack()
+
+        # Reply to the publisher with process instance details
+        reply_to = data.get("reply_to")
+        if reply_to and instance_id:
+            try:
+                await nc.publish(reply_to, json.dumps(instance_id).encode("utf-8"))
+
+            except Exception as e:
+                logger.warning("Failed to send reply to %s: %s", reply_to, e)
+
     except ApiError as e:
         # Permanent business-logic failure (e.g. missing lane users, invalid BPMN config).
         # NAKing would cause endless retries since the data won't change — ACK to discard.
@@ -313,7 +343,7 @@ async def main() -> None:
         try:
             msgs = await sub.fetch(batch=FETCH_BATCH, timeout=FETCH_TIMEOUT)
             for msg in msgs:
-                await process_message(msg, kv)
+                await process_message(msg, kv, nc)
         except TimeoutError:
             pass
         except ConnectionClosedError:

--- a/m8flow-nats-consumer/consumer.py
+++ b/m8flow-nats-consumer/consumer.py
@@ -210,7 +210,7 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
             tenant_id,
             process_identifier,
             username,
-            data.get("payload", {}),
+            data.get("payload") or {},
         )
 
         logger.info(

--- a/m8flow-nats-consumer/consumer.py
+++ b/m8flow-nats-consumer/consumer.py
@@ -253,8 +253,9 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
             except Exception as e:
                 logger.warning("Failed to send reply to %s: %s", reply_to, e)
 
-    except ApiError as e:
-        # Permanent business-logic failure (e.g. missing lane users, invalid BPMN config).
+    except (ApiError, ValueError, TypeError) as e:
+        # Permanent business-logic failure (e.g. missing lane users, invalid BPMN config,
+        # workflow script validation errors like missing required fields).
         # NAKing would cause endless retries since the data won't change — ACK to discard.
         logger.error(
             "Process instantiation failed (permanent error, discarding message): "
@@ -266,6 +267,16 @@ async def process_message(msg: Any, kv: KeyValue | None, nc: NATS) -> None:
                 await kv.delete(dedup_key)
             except Exception:
                 pass
+
+        # Reply with error details so the API can return a meaningful response
+        reply_to = data.get("reply_to")
+        if reply_to:
+            try:
+                error_reply = {"error": True, "message": str(e)}
+                await nc.publish(reply_to, json.dumps(error_reply).encode("utf-8"))
+            except Exception:
+                pass
+
         await msg.ack()
     except Exception as e:
         logger.error("Process instantiation failed (transient error, will retry): %s", e)


### PR DESCRIPTION
## JIRA Ticket

[M8F-220](https://aottech.atlassian.net/browse/M8F-220)

## Description
Implemented a synchronous API endpoint to allow external systems (e.g., Formio) to trigger M8Flow workflow processes. This implementation uses NATS JetStream for reliable message delivery while maintaining a synchronous HTTP interface by waiting for the background consumer to acknowledge the process start.

---

### API Specification

**Endpoint:** `POST /api/events/m8flow-trigger`

#### Required Headers
| Header | Description |
| :--- | :--- |
| `X-M8FLOW-Tenant-Slug` | The unique slug of the tenant. |
| `X-M8FLOW-NATS-API-Key` | A valid API key for the tenant. |
| `X-M8FLOW-Process-Identifier` | The identifier of the BPMN process to start. |
| `X-M8FLOW-Username` | The username on whose behalf the process is started. |
| `X-M8FLOW-Stream-Name` | The target NATS stream for the event. |

#### Request Body
```json
{
  "data": {
    "key_1": "value_1",
    "key_2": "value_2"
  }
}
```
### Responses

#### 1. Success (200 OK)
Returned when the process instance is successfully created.
```json
{
  "ok": true,
  "message": "Event received and process instance created.",
  "data": {
    "process_instance": {
      "id": 101,
      "status": "READY",
      "process_model_identifier": "my_process_id"
    },
    "event": { "id": "event-uuid-123" }
  }
}
```
#### 2. Business Logic Error (422 Unprocessable Entity)
Returned when a pre-condition is not met (e.g., user not found or BPMN validation error).
```json
{
  "ok": false,
  "message": "Event published but process instance creation failed.",
  "data": {
    "error": "User 'agent_007' not found in the database for tenant 'm8flow-uuid'."
  }
}
```
#### 3. Processing Timeout (202 Accepted)
Returned if the message was successfully queued in NATS, but the consumer did not respond within the 30-second timeout.
```json
{
  "ok": false,
  "message": "Event published but no response from consumer (timeout).",
  "data": {
    "process_instance": null
  }
}
```
## Type

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

### Manual API Verification
Tested the endpoint using `cURL` to ensure headers are correctly parsed and the synchronous handoff to NATS works:
*   Verified **200 OK** response when a valid process is triggered.
*   Verified that the `process_instance` details in the response match the record in the database.

### Consumer Logic & Reliability
*   Verified that the `m8flow-nats-consumer` correctly subscribes to the trigger subject.
*   Confirmed that process instances are correctly created with the provided payload.

## Related Issues

Closes # [M8F-220](https://aottech.atlassian.net/browse/M8F-220)



[M8F-220]: https://aottech.atlassian.net/browse/M8F-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M8F-220]: https://aottech.atlassian.net/browse/M8F-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ