### PR TITLE
fixed backend not starting issue

### DIFF
--- a/m8flow-backend/src/m8flow_backend/startup/sequence.py
+++ b/m8flow-backend/src/m8flow_backend/startup/sequence.py
@@ -25,7 +25,6 @@ from m8flow_backend.startup.auth_patches import apply_extension_patches_after_ap
 
 from m8flow_backend.services.asgi_tenant_context_middleware import AsgiTenantContextMiddleware
 from m8flow_backend.startup.guard import set_phase, BootPhase
-from spiffworkflow_backend.middleware.asgi_proxy_fix import ASGIProxyFix
 
 
 def _prepare_pre_app_boot() -> tuple[Any, Callable[[], None]]:
@@ -127,6 +126,9 @@ def _wrap_asgi_if_needed(cnx_app: Any) -> Any:
         proxy_count = 0
 
     if proxy_count > 0:
+        # Import lazily to ensure model override bootstrap has run first.
+        from spiffworkflow_backend.middleware.asgi_proxy_fix import ASGIProxyFix
+
         app = ASGIProxyFix(
             app,
             x_for=proxy_count,


### PR DESCRIPTION
## JIRA Ticket

<!-- Link to JIRA ticket -->

## Description

Done: backend startup no longer double-registers bpmn_process_definition
What changed
Updated m8flow-backend/src/m8flow_backend/startup/sequence.py to remove the module-scope import of ASGIProxyFix and import it lazily only when SPIFFWORKFLOW_BACKEND_PROXY_COUNT_FOR_PROXY_FIX > 0.
Why this fixes the crash
The early module-scope import could pull in spiffworkflow_backend before bootstrap() installs the model override finder, causing upstream models to register tables in SQLAlchemy metadata first; later, M8Flow models try to register the same table again → Table ... already defined.
Lazy import ensures this happens only after bootstrap().

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

<!-- How was this tested? -->


## Related Issues

Closes #

