### PR TITLE
M8F-257 : Local backend running using script issue fixed

### DIFF
--- a/m8flow-backend/bin/run_m8flow_backend.ps1
+++ b/m8flow-backend/bin/run_m8flow_backend.ps1
@@ -12,11 +12,37 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
 Set-Location $repoRoot
+$script:LauncherStartedAt = Get-Date
 
 function Test-CommandAvailable {
   param([string]$Name)
 
   return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Format-Duration {
+  param([TimeSpan]$Duration)
+
+  return '{0:00}m{1:00}s' -f [int]$Duration.TotalMinutes, $Duration.Seconds
+}
+
+function Write-LauncherStatus {
+  param([string]$Message)
+
+  $elapsed = (Get-Date) - $script:LauncherStartedAt
+  Write-Host ("m8flow-backend: [{0}] {1}" -f (Format-Duration $elapsed), $Message)
+}
+
+function Invoke-TimedStep {
+  param(
+    [string]$Label,
+    [scriptblock]$Action
+  )
+
+  $startedAt = Get-Date
+  Write-LauncherStatus "$Label..."
+  & $Action
+  Write-LauncherStatus ("{0} complete in {1}" -f $Label, (Format-Duration ((Get-Date) - $startedAt)))
 }
 
 function Test-IsRunningInContainer {
@@ -111,6 +137,58 @@ function Invoke-BackendPythonInBackendDir {
   }
 }
 
+function Test-HasM8FlowBackendRuntimeDependencies {
+  try {
+    Invoke-UvPython @('-c', 'import nats') *> $null
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Sync-LocalBackendEnvironment {
+  Push-Location (Join-Path $repoRoot 'spiffworkflow-backend')
+  try {
+    $uvSyncArgs = @('sync', '--all-groups', '--inexact')
+    if ($env:VIRTUAL_ENV) {
+      $uvSyncArgs += '--active'
+    }
+    & uv @uvSyncArgs
+
+    if (-not (Test-HasM8FlowBackendRuntimeDependencies)) {
+      $uvPipArgs = @('pip', 'install', 'nats-py>=2.6.0')
+      if ($env:VIRTUAL_ENV) {
+        $uvPipArgs += '--active'
+      }
+      & uv @uvPipArgs
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+function Invoke-SpiffDbUpgrade {
+  Invoke-BackendPythonInBackendDir @('-m', 'flask', 'db', 'upgrade')
+}
+
+function Invoke-M8FlowDbUpgrade {
+  $alembicIni = Join-Path $repoRoot 'm8flow-backend\migrations\alembic.ini'
+  Invoke-BackendPython @('-m', 'alembic', '-c', $alembicIni, 'upgrade', 'head')
+}
+
+function Invoke-BackendBootstrap {
+  Push-Location (Join-Path $repoRoot 'spiffworkflow-backend')
+  try {
+    if ($script:UseUvRunner) {
+      Invoke-UvPython @('bin/bootstrap.py')
+    } else {
+      & python 'bin/bootstrap.py'
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
 # --- .env loading (reload-friendly) ------------------------------------------
 if (-not $script:LoadedEnvKeys) { $script:LoadedEnvKeys = @() }
 
@@ -192,38 +270,19 @@ if (-not $env:UVICORN_LOG_LEVEL -and -not $runningInContainer) {
 }
 
 if ($script:UseUvRunner -and $env:M8FLOW_BACKEND_SYNC_DEPS -ne 'false') {
-  Push-Location (Join-Path $repoRoot 'spiffworkflow-backend')
-  try {
-    $uvSyncArgs = @('sync', '--all-groups')
-    if ($env:VIRTUAL_ENV) {
-      $uvSyncArgs += '--active'
-    }
-    & uv @uvSyncArgs
-  } finally {
-    Pop-Location
-  }
+  Invoke-TimedStep 'Syncing local Python environment' { Sync-LocalBackendEnvironment }
 }
 
 if ($env:M8FLOW_BACKEND_SW_UPGRADE_DB -ne 'false') {
-  Invoke-BackendPythonInBackendDir @('-m', 'flask', 'db', 'upgrade')
+  Invoke-TimedStep 'Running upstream backend migrations' { Invoke-SpiffDbUpgrade }
 }
 
 if ($env:M8FLOW_BACKEND_UPGRADE_DB -ne 'false') {
-  $alembicIni = Join-Path $repoRoot 'm8flow-backend\migrations\alembic.ini'
-  Invoke-BackendPython @('-m', 'alembic', '-c', $alembicIni, 'upgrade', 'head')
+  Invoke-TimedStep 'Running M8Flow migrations' { Invoke-M8FlowDbUpgrade }
 }
 
 if ($env:M8FLOW_BACKEND_RUN_BOOTSTRAP -ne 'false') {
-  Push-Location (Join-Path $repoRoot 'spiffworkflow-backend')
-  try {
-    if ($script:UseUvRunner) {
-      Invoke-UvPython @('bin/bootstrap.py')
-    } else {
-      & python 'bin/bootstrap.py'
-    }
-  } finally {
-    Pop-Location
-  }
+  Invoke-TimedStep 'Running backend bootstrap' { Invoke-BackendBootstrap }
 }
 
 $logConfig = Join-Path $repoRoot 'uvicorn-log.yaml'
@@ -234,6 +293,11 @@ $backendPort = if ($PSBoundParameters.ContainsKey('Port')) {
   [int]$env:M8FLOW_BACKEND_PORT
 } else {
   $defaultBackendPort
+}
+
+Write-LauncherStatus ("Preparing backend startup (port={0}, reload={1}, uv_runner={2})" -f $backendPort, [bool]$Reload, $script:UseUvRunner)
+if ($Reload) {
+  Write-LauncherStatus "Reload mode starts a reloader first, then a worker. A short quiet pause after 'Uvicorn running' is normal on first startup."
 }
 
 $uvicornArgs = @(
@@ -248,7 +312,9 @@ if ($env:UVICORN_LOG_LEVEL) {
   $uvicornArgs += @('--log-level', $env:UVICORN_LOG_LEVEL)
 }
 if ($Reload) {
-  $uvicornArgs += @('--reload', '--workers', '1')
+  $uvicornArgs += @('--reload')
+  $uvicornArgs += @('--reload-dir', (Join-Path $repoRoot 'm8flow-backend\src'))
+  $uvicornArgs += @('--reload-dir', (Join-Path $repoRoot 'm8flow-backend\migrations'))
   $uvicornArgs += @('--reload-exclude', 'm8flow-frontend/**')
   $uvicornArgs += @('--reload-exclude', '**/node_modules/**')
   $uvicornArgs += @('--reload-exclude', '**/.vite/**')
@@ -257,4 +323,5 @@ if ($Reload) {
   $uvicornArgs += @('--reload-exclude', '.git/**')
 }
 
+Write-LauncherStatus "Starting Uvicorn. The backend is ready once '/v1.0/status' returns 200."
 Invoke-BackendPython $uvicornArgs

--- a/m8flow-backend/bin/run_m8flow_backend.sh
+++ b/m8flow-backend/bin/run_m8flow_backend.sh
@@ -4,9 +4,31 @@ set -eo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/../.." && pwd)"
 cd "$repo_root"
+launcher_started_at=${SECONDS:-0}
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+format_duration() {
+  local total_seconds="$1"
+  printf '%02dm%02ds' "$((total_seconds / 60))" "$((total_seconds % 60))"
+}
+
+log_launcher_status() {
+  local elapsed
+  elapsed="$(format_duration "$((SECONDS - launcher_started_at))")"
+  printf 'm8flow-backend: [%s] %s\n' "$elapsed" "$*"
+}
+
+run_timed_step() {
+  local label="$1"
+  shift
+
+  local started_at=$SECONDS
+  log_launcher_status "$label..."
+  "$@"
+  log_launcher_status "$label complete in $(format_duration "$((SECONDS - started_at))")"
 }
 
 is_running_in_container() {
@@ -69,11 +91,62 @@ exec_uv_python() {
 
 sync_uv_environment() {
   if uv_has_active_environment; then
-    uv sync --all-groups --active
+    uv sync --all-groups --inexact --active
     return
   fi
 
-  uv sync --all-groups
+  uv sync --all-groups --inexact
+}
+
+has_m8flow_backend_runtime_dependencies() {
+  run_uv_python -c "import nats" >/dev/null 2>&1
+}
+
+sync_m8flow_backend_runtime_dependencies() {
+  local packages=(
+    "nats-py>=2.6.0"
+  )
+
+  if has_m8flow_backend_runtime_dependencies; then
+    return
+  fi
+
+  if uv_has_active_environment; then
+    uv pip install --active "${packages[@]}"
+    return
+  fi
+
+  uv pip install "${packages[@]}"
+}
+
+sync_local_backend_environment() {
+  cd "$repo_root/spiffworkflow-backend"
+  sync_uv_environment
+  sync_m8flow_backend_runtime_dependencies
+  cd "$repo_root"
+}
+
+run_spiff_db_upgrade() {
+  run_python_module_in_backend_dir flask db upgrade
+}
+
+run_m8flow_db_upgrade() {
+  run_python_module alembic -c "$repo_root/m8flow-backend/migrations/alembic.ini" upgrade head
+}
+
+run_backend_bootstrap() {
+  if [[ "$use_uv_runner" == "true" ]]; then
+    (
+      cd "$repo_root/spiffworkflow-backend"
+      run_uv_python bin/bootstrap.py
+    )
+    return
+  fi
+
+  (
+    cd "$repo_root/spiffworkflow-backend"
+    python bin/bootstrap.py
+  )
 }
 
 run_python_module() {
@@ -187,32 +260,25 @@ if [[ -z "${UVICORN_LOG_LEVEL:-}" && ! is_running_in_container ]]; then
   export UVICORN_LOG_LEVEL=debug
 fi
 
+log_launcher_status "Preparing backend startup (port=${port_arg:-${M8FLOW_BACKEND_PORT:-7000}}, reload=${reload_mode}, uv_runner=${use_uv_runner})"
+if [[ "$reload_mode" == "true" ]]; then
+  log_launcher_status "Reload mode starts a reloader first, then a worker. A short quiet pause after 'Uvicorn running' is normal on first startup."
+fi
+
 if [[ "$use_uv_runner" == "true" && "${M8FLOW_BACKEND_SYNC_DEPS:-true}" != "false" ]]; then
-  cd "$repo_root/spiffworkflow-backend"
-  sync_uv_environment
-  cd "$repo_root"
+  run_timed_step "Syncing local Python environment" sync_local_backend_environment
 fi
 
 if [[ "${M8FLOW_BACKEND_SW_UPGRADE_DB:-true}" != "false" ]]; then
-  run_python_module_in_backend_dir flask db upgrade
+  run_timed_step "Running upstream backend migrations" run_spiff_db_upgrade
 fi
 
 if [[ "${M8FLOW_BACKEND_UPGRADE_DB:-true}" != "false" ]]; then
-  run_python_module alembic -c "$repo_root/m8flow-backend/migrations/alembic.ini" upgrade head
+  run_timed_step "Running M8Flow migrations" run_m8flow_db_upgrade
 fi
 
 if [[ "${M8FLOW_BACKEND_RUN_BOOTSTRAP:-}" != "false" ]]; then
-  if [[ "$use_uv_runner" == "true" ]]; then
-    (
-      cd "$repo_root/spiffworkflow-backend"
-      run_uv_python bin/bootstrap.py
-    )
-  else
-    (
-      cd "$repo_root/spiffworkflow-backend"
-      python bin/bootstrap.py
-    )
-  fi
+  run_timed_step "Running backend bootstrap" run_backend_bootstrap
 fi
 
 log_config="$repo_root/uvicorn-log.yaml"
@@ -224,7 +290,9 @@ uvicorn_args=(--host 0.0.0.0 --port "$backend_port" --app-dir "$repo_root" --log
 [[ -f "$env_file" ]] && uvicorn_args+=(--env-file "$env_file")
 [[ -n "${UVICORN_LOG_LEVEL:-}" ]] && uvicorn_args+=(--log-level "$UVICORN_LOG_LEVEL")
 if [[ "$reload_mode" == "true" ]]; then
-  uvicorn_args+=(--reload --workers 1)
+  uvicorn_args+=(--reload)
+  uvicorn_args+=(--reload-dir "$repo_root/m8flow-backend/src")
+  uvicorn_args+=(--reload-dir "$repo_root/m8flow-backend/migrations")
   uvicorn_args+=(--reload-exclude "m8flow-frontend/**")
   uvicorn_args+=(--reload-exclude "**/node_modules/**")
   uvicorn_args+=(--reload-exclude "**/.vite/**")
@@ -233,4 +301,5 @@ if [[ "$reload_mode" == "true" ]]; then
   uvicorn_args+=(--reload-exclude ".git/**")
 fi
 
+log_launcher_status "Starting Uvicorn. The backend is ready once '/v1.0/status' returns 200."
 exec_python_module uvicorn m8flow_backend.app:app "${uvicorn_args[@]}"


### PR DESCRIPTION
## JIRA Ticket

[M8F-257](https://aottech.atlassian.net/browse/M8F-257)

## Description

Fixed a local backend startup failure in `run_m8flow_backend.sh`. The main issue was that local development startup did not install the M8Flow-specific `nats-py` dependency required by the backend event routes, which caused the backend to fail during route initialization. Also updated the launcher to preserve that dependency across reruns and added clearer startup progress logs to make local startup behavior easier to understand.


## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

- Started the backend locally with `./m8flow-backend/bin/run_m8flow_backend.sh 7000 --reload`
- Verified the backend successfully started in reload mode
- Confirmed `GET /v1.0/status` returned `200 OK`
- Verified the frontend loaded successfully after backend startup

## Related Issues

Closes #[M8F-257](https://aottech.atlassian.net/browse/M8F-257)



[M8F-257]: https://aottech.atlassian.net/browse/M8F-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M8F-257]: https://aottech.atlassian.net/browse/M8F-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ