### PR TITLE
M8F 220 : Implement explicit tenant context resolution for event handling

### DIFF
--- a/m8flow-backend/src/m8flow_backend/routes/events_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/events_controller.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from flask import request
+from flask import g, request
 from spiffworkflow_backend.exceptions.api_error import ApiError
 
 from m8flow_backend.helpers.response_helper import handle_api_errors, success_response
@@ -11,8 +11,15 @@ from m8flow_backend.services.nats_token_service import NatsTokenService
 
 from m8flow_backend.services.nats_service import NatsService
 from m8flow_backend.services.tenant_service import TenantService
+from m8flow_backend.tenancy import get_context_tenant_id, set_context_tenant_id
 
 logger = logging.getLogger("m8flow.events.controller")
+
+
+def _set_validated_tenant_context(tenant_id: str) -> None:
+    g.m8flow_tenant_id = tenant_id
+    if get_context_tenant_id() != tenant_id:
+        g._m8flow_ctx_token = set_context_tenant_id(tenant_id)
 
 
 def _resolve_tenant_and_validate_key() -> tuple[str, str, str]:
@@ -80,6 +87,7 @@ def m8flow_trigger() -> tuple:
     }
     """
     tenant_id, tenant_slug, api_key = _resolve_tenant_and_validate_key()
+    _set_validated_tenant_context(tenant_id)
 
     process_identifier = request.headers.get("X-M8FLOW-Process-Identifier")
     username = request.headers.get("X-M8FLOW-Username")
@@ -177,4 +185,4 @@ def m8flow_trigger() -> tuple:
     )
 
 
-
+m8flow_trigger._m8flow_sets_tenant_context = True  # type: ignore[attr-defined]

--- a/m8flow-backend/src/m8flow_backend/startup/tenant_resolution.py
+++ b/m8flow-backend/src/m8flow_backend/startup/tenant_resolution.py
@@ -1,9 +1,34 @@
 # extensions/startup/tenant_resolution.py
+from __future__ import annotations
+
+from typing import Any
+
+
+def _view_function_sets_tenant_context(view_function: Any) -> bool:
+    visited: set[int] = set()
+    while view_function is not None and id(view_function) not in visited:
+        visited.add(id(view_function))
+        if getattr(view_function, "_m8flow_sets_tenant_context", False):
+            return True
+        view_function = getattr(view_function, "__wrapped__", None)
+    return False
+
+
+def _request_controller_sets_tenant_context(flask_app) -> bool:
+    from flask import request
+
+    endpoint = getattr(request, "endpoint", None)
+    if not endpoint:
+        return False
+    return _view_function_sets_tenant_context(flask_app.view_functions.get(endpoint))
+
 
 def register_tenant_resolution_after_auth(flask_app) -> None:
     from m8flow_backend.services.tenant_context_middleware import resolve_request_tenant
 
     def _resolve_tenant_after_auth():
+        if _request_controller_sets_tenant_context(flask_app):
+            return None
         return resolve_request_tenant()
 
     def _is_auth_before_request(func) -> bool:


### PR DESCRIPTION
## JIRA Ticket

[M8F-220](https://aottech.atlassian.net/browse/M8F-220)

## Description
Fixes deployed external trigger API calls without Bearer auth.

The event trigger endpoint now owns tenant context itself: after resolving the tenant slug and validating `X-M8FLOW-NATS-API-Key`, it sets API-side tenant context before publishing to NATS.

## Changes

- Defer global tenant resolution for controllers that set tenant context themselves.
- Set tenant context in `m8flow_trigger()` only after NATS API key validation.
- Add tests for valid/invalid API key tenant-context behavior.

## Notes

- Bearer auth is still not required.
- No generic path/header fallback was added.
- Consumer-side tenant context remains unchanged.
- No upstream SpiffArena files were modified.



## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

in swagger tested the api

## Related Issues

Closes #



[M8F-220]: https://aottech.atlassian.net/browse/M8F-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ