### PR TITLE
inital fix for lane

### DIFF
--- a/m8flow-backend/src/m8flow_backend/services/process_instance_processor_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/process_instance_processor_patch.py
@@ -31,6 +31,48 @@ def apply() -> None:
     from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
     from spiffworkflow_backend.services.user_service import UserService
 
+    def _resolve_lane_owners(task: SpiffTask) -> dict | None:
+        lane_owners = getattr(task, "data", None)
+        if isinstance(lane_owners, dict):
+            candidate = lane_owners.get("lane_owners")
+            if isinstance(candidate, dict) and candidate:
+                return candidate
+
+        task_workflow = getattr(task, "workflow", None)
+        if task_workflow is not None:
+            workflow_data = getattr(task_workflow, "data", None)
+            if isinstance(workflow_data, dict):
+                workflow_data_objects = workflow_data.get("data_objects")
+                if isinstance(workflow_data_objects, dict):
+                    candidate = workflow_data_objects.get("lane_owners")
+                    if isinstance(candidate, dict) and candidate:
+                        return candidate
+
+                candidate = workflow_data.get("lane_owners")
+                if isinstance(candidate, dict) and candidate:
+                    return candidate
+
+            workflow_data_objects_attr = getattr(task_workflow, "data_objects", None)
+            if isinstance(workflow_data_objects_attr, dict):
+                candidate = workflow_data_objects_attr.get("lane_owners")
+                if isinstance(candidate, dict) and candidate:
+                    return candidate
+
+            if hasattr(ProcessInstanceProcessor, "get_tasks_with_data"):
+                completed_tasks_with_data = ProcessInstanceProcessor.get_tasks_with_data(task_workflow)
+                for completed_task in sorted(
+                    completed_tasks_with_data,
+                    key=_task_sort_ts,
+                ):
+                    completed_task_data = getattr(completed_task, "data", None)
+                    if not isinstance(completed_task_data, dict) or not completed_task_data:
+                        continue
+                    candidate = completed_task_data.get("lane_owners")
+                    if isinstance(candidate, dict) and candidate:
+                        return candidate
+
+        return None
+
     def patched_get_potential_owners_from_task(self: ProcessInstanceProcessor, task: SpiffTask) -> PotentialOwnerIdList:
         """Resolve guest, initiator, lane-assignment, and lane-owner users within the current tenant."""
         task_spec = task.task_spec
@@ -56,8 +98,9 @@ def apply() -> None:
         else:
             group_model = UserService.find_or_create_group(task_lane)
             lane_assignment_id = group_model.id
-            if "lane_owners" in task.data and task_lane in task.data["lane_owners"]:
-                for username_or_email in task.data["lane_owners"][task_lane]:
+            resolved_lane_owners = _resolve_lane_owners(task)
+            if isinstance(resolved_lane_owners, dict) and task_lane in resolved_lane_owners:
+                for username_or_email in resolved_lane_owners[task_lane]:
                     for lane_owner_user in find_users_for_current_tenant_by_identifier(username_or_email):
                         potential_owners.append(
                             {"added_by": HumanTaskUserAddedBy.lane_owner.value, "user_id": lane_owner_user.id}
@@ -67,7 +110,7 @@ def apply() -> None:
                     (
                         "No users found in task data lane owner list for lane:"
                         f" {task_lane}. The user list used:"
-                        f" {task.data['lane_owners'][task_lane]}"
+                        f" {resolved_lane_owners[task_lane]}"
                     ),
                 )
             else:

--- a/m8flow-backend/src/m8flow_backend/services/process_instance_service_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/process_instance_service_patch.py
@@ -27,6 +27,7 @@ def apply() -> None:
 
     from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
     from spiffworkflow_backend.models.db import db
+    from spiffworkflow_backend.models.human_task import HumanTaskModel
     from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
     from spiffworkflow_backend.services.process_instance_queue_service import ProcessInstanceQueueService
     from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
@@ -174,21 +175,35 @@ def apply() -> None:
             if merged_data_objects:
                 processor.bpmn_process_instance.data["data_objects"] = merged_data_objects
 
-        if status_value and cls.can_optimistically_skip(processor, status_value):
-            current_app.logger.info(f"Optimistically skipped process_instance {process_instance.id}")
-            return (processor, task_runnability)
+            if status_value and cls.can_optimistically_skip(processor, status_value):
+                current_app.logger.info(f"Optimistically skipped process_instance {process_instance.id}")
+                return (processor, task_runnability)
 
-        db.session.refresh(process_instance)
-        if status_value is None or process_instance.status == status_value:
-            task_runnability = processor.do_engine_steps(
-                save=True,
-                execution_strategy_name=execution_strategy_name,
-                should_schedule_waiting_timer_events=should_schedule_waiting_timer_events,
-            )
+            db.session.refresh(process_instance)
+            if status_value is None or process_instance.status == status_value:
+                task_runnability = processor.do_engine_steps(
+                    save=True,
+                    execution_strategy_name=execution_strategy_name,
+                    should_schedule_waiting_timer_events=should_schedule_waiting_timer_events,
+                )
 
         return (processor, task_runnability)
+
+    original_spiff_task_to_api_task = ProcessInstanceService.spiff_task_to_api_task
+
+    @staticmethod
+    def patched_spiff_task_to_api_task(processor, spiff_task):  # type: ignore[override]
+        """Guard against potential owners with None email/username."""
+        task_guid = str(spiff_task.id)
+        human_task = HumanTaskModel.query.filter_by(task_id=task_guid).first()
+        if human_task is not None:
+            for owner in human_task.potential_owners:
+                if owner is not None and getattr(owner, "email", None) is None:
+                    owner.email = getattr(owner, "username", None) or str(getattr(owner, "id", ""))
+        return original_spiff_task_to_api_task(processor, spiff_task)
 
     ProcessInstanceService.create_process_instance = patched_create_process_instance  # type: ignore[assignment]
     ProcessInstanceService.update_form_task_data = patched_update_form_task_data
     ProcessInstanceService.run_process_instance_with_processor = patched_run_process_instance_with_processor
+    ProcessInstanceService.spiff_task_to_api_task = patched_spiff_task_to_api_task
     _PATCHED = True


### PR DESCRIPTION
## JIRA Ticket
https://aottech.atlassian.net/browse/M8F-253

## Description


Fixes an intermittent bug where tasks assigned to lane-based users (reviewer, admin) were missing after form submission in multi-step approval workflows. The issue was reproducible with the `template-two-step-leave-approval-with-email-notifications-V1` template where the Manager (reviewer) task would sometimes not appear, and the HR (admin) task would never appear after manager approval.

Three root causes were identified and fixed:

1. **Race condition in process instance processing** -- `do_engine_steps` was executing outside the queue lock, allowing concurrent modifications to corrupt task state.
2. **`lane_owners` data lost after form submission** -- upstream `update_form_task_data` overwrites `task.data`, causing `lane_owners` to be unavailable for subsequent lane-based task assignment.
3. **`TypeError` crash on task serialization** -- potential owners with `None` email fields caused `",".join(user_list)` to fail when serializing tasks for the API.

---

## Changes

### 1. `process_instance_service_patch.py`

**Fix race condition (lock scope):**

Moved `can_optimistically_skip`, `db.session.refresh`, and `processor.do_engine_steps` inside the `ProcessInstanceQueueService.dequeued` context manager to ensure atomic execution under the queue lock. Previously these ran after the lock was released, allowing a concurrent request to process the same instance and lose the newly created human task.

```
Before:
    with ProcessInstanceQueueService.dequeued(process_instance):
        # ... build processor, merge data ...
                                                          # lock released here
    if status_value and cls.can_optimistically_skip(...)   # <-- outside lock
    db.session.refresh(process_instance)                   # <-- outside lock
    processor.do_engine_steps(save=True, ...)              # <-- outside lock

After:
    with ProcessInstanceQueueService.dequeued(process_instance):
        # ... build processor, merge data ...
        if status_value and cls.can_optimistically_skip(...)   # inside lock
        db.session.refresh(process_instance)                   # inside lock
        processor.do_engine_steps(save=True, ...)              # inside lock
```

**Fix `TypeError` in `spiff_task_to_api_task`:**

Added a lightweight patch that, before calling the original upstream method, checks each potential owner on the human task and sets `email` to a fallback value (`username` or `id`) if it is `None`. This prevents the upstream `",".join(...)` from crashing with `TypeError: sequence item 0: expected str instance, NoneType found`.

### 2. `process_instance_processor_patch.py`

**Fix `lane_owners` data propagation:**

Added a `_resolve_lane_owners` helper that searches for the `lane_owners` dictionary across multiple data sources in priority order:

1. `task.data` (direct task-level data)
2. `task.workflow.data["data_objects"]` (workflow-level data objects)
3. `task.workflow.data` (top-level workflow data)
4. `task.workflow.data_objects` (workflow data_objects attribute)
5. Completed task data scan (iterates previously completed tasks)

Updated `patched_get_potential_owners_from_task` to use this helper instead of only checking `task.data["lane_owners"]`, which was empty after the upstream form data overwrite.

---

## Files Changed

| File | Change |
|------|--------|
| `m8flow-backend/src/m8flow_backend/services/process_instance_service_patch.py` | Move engine steps inside queue lock; add `spiff_task_to_api_task` patch for None email safety |
| `m8flow-backend/src/m8flow_backend/services/process_instance_processor_patch.py` | Add `_resolve_lane_owners` helper; update lane owner resolution to search workflow-level data |

---

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

<!-- How was this tested? -->


## Related Issues

Closes #

