### PR TITLE
fix: update template gallery table styles to prevent text overflow with minWidth and word-break

### DIFF
--- a/m8flow-frontend/src/views/TemplateGalleryPage.tsx
+++ b/m8flow-frontend/src/views/TemplateGalleryPage.tsx
@@ -201,7 +201,7 @@ export default function TemplateGalleryPage() {
               paginationDataTestidTag="template-gallery-pagination"
               tableToDisplay={
                 <TableContainer component={Paper} elevation={0} sx={{ border: '1px solid', borderColor: 'borders.primary', borderRadius: 2 }}>
-                    <Table size="medium" className="process-model-file-table" data-testid="template-gallery-table">
+                    <Table size="medium" sx={{ minWidth: 650, '& td': { wordBreak: 'break-word' } }} data-testid="template-gallery-table">
                     <TableHead>
                       <TableRow>
                         <TableCell>{t("name")}</TableCell>


### PR DESCRIPTION
## JIRA Ticket

[M8F-256](https://aottech.atlassian.net/browse/M8F-256)

## Description

This PR fixes a UI bug in the Template Gallery's table/list view where long template names and keys would overflow their table cells and overlap with text in adjacent columns.

The issue was caused by an inherited upstream CSS class (`process-model-file-table`) on the `<Table>` component, which was incorrectly enforcing `table-layout: fixed` and `white-space: nowrap` without hiding the overflow.

**Changes made:**
- Removed the `process-model-file-table` class from the Template Gallery table.
- Added standard Material UI layout properties (`sx={{ minWidth: 650, '& td': { wordBreak: 'break-word' } }}`) to restore responsive column widths and allow long strings to break and wrap cleanly onto new lines.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [x] Frontend
- [ ] Documentation

## Testing

Tested locally by rendering the Template Gallery in "Table View" with data containing long names and keys (e.g., "Postgresql Table Lifecycle Management"). Verified that the table columns now dynamically adjust their widths and long strings successfully wrap to a new line without overlapping neighboring cells.

## Related Issues

Closes #


[M8F-256]: https://aottech.atlassian.net/browse/M8F-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ