### PR TITLE
feat: add m8flow-connector-github dependency via git source

### DIFF
--- a/m8flow-connector-proxy/poetry.lock
+++ b/m8flow-connector-proxy/poetry.lock
@@ -298,6 +298,27 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "m8flow-connector-github"
+version = "1.0.0"
+description = "GitHub connector for m8flow: connect to repository, list pull requests, list branches"
+optional = false
+python-versions = "^3.12.1"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+requests = "^2.28.1"
+spiffworkflow-connector-command = {git = "https://github.com/sartography/spiffworkflow-connector-command.git", rev = "main"}
+
+[package.source]
+type = "git"
+url = "https://github.com/AOT-Technologies/m8flow-connectors.git"
+reference = "b6abaef7786f6c7eabae4eb19f424124461df5e1"
+resolved_reference = "b6abaef7786f6c7eabae4eb19f424124461df5e1"
+subdirectory = "connectors/m8flow-connector-github"
+
+[[package]]
 name = "m8flow-connector-salesforce"
 version = "1.0.0"
 description = "Salesforce connector for m8flow: CRUD for Lead and Contact with OAuth"
@@ -680,4 +701,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12.1,<3.13"
-content-hash = "4cb59fea4b3859aa6b3bd69e97035d183c508dc784996359f45883905debd541"
+content-hash = "fdf5839914be125c640f582c9f3fc86af339943b363768582cf2856a55ccc8e9"

--- a/m8flow-connector-proxy/pyproject.toml
+++ b/m8flow-connector-proxy/pyproject.toml
@@ -16,6 +16,7 @@ m8flow-connector-smtp = { git = "https://github.com/AOT-Technologies/m8flow-conn
 m8flow-connector-slack = { git = "https://github.com/AOT-Technologies/m8flow-connectors.git", subdirectory = "connectors/m8flow-connector-slack", tag = "1.0.0" }
 m8flow-connector-salesforce = { git = "https://github.com/AOT-Technologies/m8flow-connectors.git", subdirectory = "connectors/m8flow-connector-salesforce", tag = "1.0.0" }
 m8flow-connector-stripe = { git = "https://github.com/AOT-Technologies/m8flow-connectors.git", subdirectory = "connectors/m8flow-connector-stripe", tag = "1.0.0" }
+m8flow-connector-github = { git = "https://github.com/AOT-Technologies/m8flow-connectors.git", subdirectory = "connectors/m8flow-connector-github", rev = "b6abaef7786f6c7eabae4eb19f424124461df5e1" }
 connector-postgres-v2 = { git = "https://github.com/sartography/connector-postgres.git", rev = "af95cbc52c326bc925e185009ea5888f3a5869be" }
 connector-http = { git = "https://github.com/sartography/connector-http.git", tag = "v0.0.1" }
 psycopg2-binary = "^2.9.9"


### PR DESCRIPTION
## JIRA Ticket

[M8F-247](https://aottech.atlassian.net/browse/M8F-247)

## Description

Integrated the GitHub connector into the `m8flow-connector-proxy` service to enable repository management operations (e.g., connecting to repos, listing branches, and listing pull requests) directly within M8Flow workflows.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

- Updated `pyproject.toml` to include `m8flow-connector-github`.
- Regenerated `poetry.lock` to ensure dependency consistency.
- Verified successful Docker build and deployment of the `m8flow-connector-proxy` container.
- Confirmed the entire stack is operational via `docker compose`.
- [github-repo-explorer.zip](https://github.com/user-attachments/files/27792199/github-repo-explorer.zip)


## Related Issues

Closes #


[M8F-247]: https://aottech.atlassian.net/browse/M8F-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ