### PR TITLE
Bugfix - Timer events not working

### DIFF
--- a/m8flow-backend/src/m8flow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/m8flow-backend/src/m8flow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -7,6 +7,7 @@ which keeps Flower UI and ``send_task()`` calls branded consistently.
 
 from __future__ import annotations
 
+from contextvars import Token
 from typing import Any
 
 from celery import shared_task
@@ -15,6 +16,12 @@ from m8flow_backend.background_processing import (
     M8FLOW_CELERY_TASK_EVENT_NOTIFIER,
     M8FLOW_CELERY_TASK_PROCESS_INSTANCE_RUN,
 )
+from m8flow_backend.services.celery_worker_runtime import cleanup_scoped_session
+from m8flow_backend.services.celery_worker_runtime import tenant_id_for_process_instance
+from m8flow_backend.services.celery_tenant_context_patch import TENANT_HEADER_NAME
+from m8flow_backend.tenancy import reset_context_tenant_id
+from m8flow_backend.tenancy import set_context_tenant_id
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.background_processing.celery_tasks.process_instance_task import (
     TEN_MINUTES,
 )
@@ -26,11 +33,54 @@ from spiffworkflow_backend.background_processing.celery_tasks.process_instance_t
 )
 
 
+def _task_tenant_id(self: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | None:
+    request = getattr(self, "request", None)
+    headers = getattr(request, "headers", None)
+    if isinstance(headers, dict):
+        header_tenant = headers.get(TENANT_HEADER_NAME)
+        if isinstance(header_tenant, str) and header_tenant:
+            return header_tenant
+
+    process_instance_id = kwargs.get("process_instance_id")
+    if process_instance_id is None and args:
+        process_instance_id = args[0]
+
+    if isinstance(process_instance_id, str) and process_instance_id.isdigit():
+        process_instance_id = int(process_instance_id)
+
+    if isinstance(process_instance_id, int):
+        return tenant_id_for_process_instance(db.engine, process_instance_id)
+    return None
+
+
+def _begin_task(self: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Token | None:
+    cleanup_scoped_session(db.session)
+
+    tenant_id = _task_tenant_id(self, args, kwargs)
+    if tenant_id:
+        return set_context_tenant_id(tenant_id)
+    return None
+
+
+def _end_task(token: Token | None) -> None:
+    cleanup_scoped_session(db.session)
+    if token is not None:
+        reset_context_tenant_id(token)
+
+
 @shared_task(name=M8FLOW_CELERY_TASK_PROCESS_INSTANCE_RUN, bind=True, ignore_result=False, time_limit=TEN_MINUTES)
 def celery_task_process_instance_run(self: Any, *args: Any, **kwargs: Any) -> dict:  # type: ignore[type-arg]
-    return _upstream_process_instance_run.run(*args, **kwargs)
+    token = _begin_task(self, args, kwargs)
+    try:
+        return _upstream_process_instance_run.run(*args, **kwargs)
+    finally:
+        _end_task(token)
 
 
 @shared_task(name=M8FLOW_CELERY_TASK_EVENT_NOTIFIER, bind=True, ignore_result=False, time_limit=TEN_MINUTES)
 def celery_task_event_notifier_run(self: Any, *args: Any, **kwargs: Any) -> dict:  # type: ignore[type-arg]
-    return _upstream_event_notifier_run.run(*args, **kwargs)
+    token = _begin_task(self, args, kwargs)
+    try:
+        return _upstream_event_notifier_run.run(*args, **kwargs)
+    finally:
+        _end_task(token)

--- a/m8flow-backend/src/m8flow_backend/background_processing/celery_worker.py
+++ b/m8flow-backend/src/m8flow_backend/background_processing/celery_worker.py
@@ -6,13 +6,15 @@ from contextvars import Token
 from typing import Any
 
 import celery
-from sqlalchemy import text
 
 from m8flow_backend.app import app as m8flow_app
 from m8flow_backend.background_processing import M8FLOW_CELERY_TASK_EVENT_NOTIFIER as CELERY_TASK_EVENT_NOTIFIER
 from m8flow_backend.background_processing import (
     M8FLOW_CELERY_TASK_PROCESS_INSTANCE_RUN as CELERY_TASK_PROCESS_INSTANCE_RUN,
 )
+from m8flow_backend.services.celery_worker_runtime import cleanup_scoped_session
+from m8flow_backend.services.celery_worker_runtime import reset_engine_for_worker_process
+from m8flow_backend.services.celery_worker_runtime import tenant_id_for_process_instance
 from m8flow_backend.services.celery_tenant_context_patch import TENANT_HEADER_NAME
 from m8flow_backend.tenancy import reset_context_tenant_id
 from m8flow_backend.tenancy import set_context_tenant_id
@@ -85,13 +87,7 @@ def _extract_process_instance_id(task_name: str, args: Any, kwargs: Any) -> int 
 
 
 def _tenant_id_for_process_instance(process_instance_id: int) -> str | None:
-    tenant_id = db.session.execute(
-        text("SELECT m8f_tenant_id FROM process_instance WHERE id = :process_instance_id"),
-        {"process_instance_id": process_instance_id},
-    ).scalar()
-    if isinstance(tenant_id, str) and tenant_id:
-        return tenant_id
-    return None
+    return tenant_id_for_process_instance(db.engine, process_instance_id)
 
 
 @celery.signals.task_prerun.connect  # type: ignore
@@ -100,6 +96,10 @@ def set_tenant_context_for_task(
 ) -> None:
     if task is None:
         return
+    if task.name in {CELERY_TASK_PROCESS_INSTANCE_RUN, CELERY_TASK_EVENT_NOTIFIER}:
+        return
+
+    cleanup_scoped_session(db.session)
 
     tenant_id: str | None = None
     request = getattr(task, "request", None)
@@ -119,7 +119,12 @@ def set_tenant_context_for_task(
 
 
 @celery.signals.task_postrun.connect  # type: ignore
-def clear_tenant_context_for_task(task_id: str | None = None, **_signal_kwargs: Any) -> None:
+def clear_tenant_context_for_task(task_id: str | None = None, task: Any | None = None, **_signal_kwargs: Any) -> None:
+    if task is not None and task.name in {CELERY_TASK_PROCESS_INSTANCE_RUN, CELERY_TASK_EVENT_NOTIFIER}:
+        return
+
+    cleanup_scoped_session(db.session)
+
     if task_id is None:
         return
     token = _TASK_TENANT_TOKENS.pop(task_id, None)
@@ -135,3 +140,9 @@ def setup_loggers(logger: Any, *args: Any, **kwargs: Any) -> None:
     stdout_handler.setFormatter(log_formatter)
     logger.addHandler(stdout_handler)
     setup_logger_for_app(the_flask_app, logger, force_run_with_celery=True)
+
+
+@celery.signals.worker_process_init.connect  # type: ignore
+def reset_db_connections_for_worker_process(**_signal_kwargs: Any) -> None:
+    with the_flask_app.app_context():
+        reset_engine_for_worker_process(db.engine, db.session)

--- a/m8flow-backend/src/m8flow_backend/services/celery_worker_runtime.py
+++ b/m8flow-backend/src/m8flow_backend/services/celery_worker_runtime.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+
+def tenant_id_for_process_instance(engine: Any, process_instance_id: int) -> str | None:
+    """Look up a process instance tenant without touching the scoped ORM session."""
+    with engine.connect() as connection:
+        tenant_id = connection.execute(
+            text("SELECT m8f_tenant_id FROM process_instance WHERE id = :process_instance_id"),
+            {"process_instance_id": process_instance_id},
+        ).scalar()
+    if isinstance(tenant_id, str) and tenant_id:
+        return tenant_id
+    return None
+
+
+def cleanup_scoped_session(session: Any) -> None:
+    """Reset a scoped session between Celery tasks so worker state does not leak."""
+    rollback = getattr(session, "rollback", None)
+    if callable(rollback):
+        try:
+            rollback()
+        except Exception:
+            pass
+
+    remove = getattr(session, "remove", None)
+    if callable(remove):
+        try:
+            remove()
+        except Exception:
+            pass
+
+
+def reset_engine_for_worker_process(engine: Any, session: Any) -> None:
+    """Dispose inherited DB connections after a Celery prefork child starts."""
+    cleanup_scoped_session(session)
+
+    dispose = getattr(engine, "dispose", None)
+    if callable(dispose):
+        try:
+            dispose()
+        except Exception:
+            pass

--- a/m8flow-backend/src/m8flow_backend/services/process_instance_service_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/process_instance_service_patch.py
@@ -4,6 +4,7 @@ import hashlib
 import time
 
 from flask import current_app
+from flask import g
 
 _PATCHED = False
 
@@ -15,6 +16,59 @@ def _task_sort_ts(task: object) -> float:
     if hasattr(val, "timestamp"):
         return val.timestamp()
     return 0.0
+
+
+def _normalized_string_attr(obj: object, attr_name: str) -> str | None:
+    value = getattr(obj, attr_name, None)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if normalized:
+        return normalized
+    return None
+
+
+def _safe_potential_owner_label(user: object) -> str | None:
+    """Return the best available stable label for a potential owner."""
+    for attr_name in ("email", "username", "display_name", "service_id"):
+        normalized = _normalized_string_attr(user, attr_name)
+        if normalized:
+            return normalized
+
+    return None
+
+
+def _safe_potential_owner_usernames(human_task: object) -> str | None:
+    """Serialize potential owners without assuming email is always present."""
+    potential_owners = getattr(human_task, "potential_owners", None)
+    if not potential_owners:
+        return None
+
+    serialized_labels: list[str] = []
+    seen: set[str] = set()
+    human_task_id = getattr(human_task, "id", None)
+    human_task_task_id = getattr(human_task, "task_id", None)
+
+    for potential_owner in potential_owners:
+        label = _safe_potential_owner_label(potential_owner)
+        if label is None:
+            current_app.logger.warning(
+                "Skipping potential owner with no usable identifier for human_task id=%s task_id=%s user_id=%s",
+                human_task_id,
+                human_task_task_id,
+                getattr(potential_owner, "id", None),
+            )
+            continue
+
+        if label in seen:
+            continue
+        seen.add(label)
+        serialized_labels.append(label)
+
+    if not serialized_labels:
+        return None
+
+    return ",".join(serialized_labels)
 
 
 def _raise_lane_assignment_api_error(
@@ -95,6 +149,7 @@ def apply() -> None:
     from spiffworkflow_backend.services.workflow_execution_service import TaskRunnability
 
     original_create_process_instance = ProcessInstanceService.create_process_instance
+    original_spiff_task_to_api_task = getattr(ProcessInstanceService, "spiff_task_to_api_task", None)
     original_update_form_task_data = ProcessInstanceService.update_form_task_data
 
     @classmethod  # type: ignore[misc]
@@ -282,8 +337,98 @@ def apply() -> None:
 
         return (processor, task_runnability)
 
+    @staticmethod
+    def patched_spiff_task_to_api_task(processor, spiff_task):
+        from SpiffWorkflow.util.task import TaskState  # type: ignore
+        from spiffworkflow_backend.exceptions.error import HumanTaskAlreadyCompletedError
+        from spiffworkflow_backend.exceptions.error import HumanTaskNotFoundError
+        from spiffworkflow_backend.exceptions.error import UserDoesNotHaveAccessToTaskError
+        from spiffworkflow_backend.models.group import GroupModel
+        from spiffworkflow_backend.models.human_task import HumanTaskModel
+        from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventModel
+        from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventType
+        from spiffworkflow_backend.models.task import Task
+        from spiffworkflow_backend.services.authorization_service import AuthorizationService
+
+        if callable(original_spiff_task_to_api_task):
+            try:
+                return original_spiff_task_to_api_task(processor, spiff_task)
+            except TypeError as exc:
+                if "expected str instance" not in str(exc) or "NoneType found" not in str(exc):
+                    raise
+
+        task_type = spiff_task.task_spec.description
+        task_guid = str(spiff_task.id)
+
+        props = {}
+        if hasattr(spiff_task.task_spec, "extensions"):
+            for key, val in spiff_task.task_spec.extensions.items():
+                props[key] = val
+
+        if hasattr(spiff_task.task_spec, "lane"):
+            lane = spiff_task.task_spec.lane
+        else:
+            lane = None
+
+        can_complete = False
+        try:
+            AuthorizationService.assert_user_can_complete_task(processor.process_instance_model.id, task_guid, g.user)
+            can_complete = True
+        except HumanTaskAlreadyCompletedError:
+            can_complete = False
+        except HumanTaskNotFoundError:
+            can_complete = False
+        except UserDoesNotHaveAccessToTaskError:
+            can_complete = False
+
+        assigned_user_group_identifier = None
+        potential_owner_usernames = None
+        if can_complete is False:
+            human_task = HumanTaskModel.query.filter_by(task_id=task_guid).first()
+            if human_task is not None:
+                if human_task.lane_assignment_id is not None:
+                    group = GroupModel.query.filter_by(id=human_task.lane_assignment_id).first()
+                    if group is not None:
+                        assigned_user_group_identifier = group.identifier
+                elif len(human_task.potential_owners) > 0:
+                    potential_owner_usernames = _safe_potential_owner_usernames(human_task)
+
+        parent_id = None
+        if spiff_task.parent:
+            parent_id = spiff_task.parent.id
+
+        serialized_task_spec = processor.serialize_task_spec(spiff_task.task_spec)
+
+        error_message = None
+        error_event = ProcessInstanceEventModel.query.filter_by(
+            task_guid=task_guid, event_type=ProcessInstanceEventType.task_failed.value
+        ).first()
+        if error_event:
+            error_message = error_event.error_details[-1].message
+
+        return Task(
+            spiff_task.id,
+            spiff_task.task_spec.bpmn_id,
+            spiff_task.task_spec.bpmn_name,
+            task_type,
+            TaskState.get_name(spiff_task.state),
+            can_complete=can_complete,
+            lane=lane,
+            process_identifier=spiff_task.task_spec._wf_spec.name,
+            process_instance_id=processor.process_instance_model.id,
+            process_model_identifier=processor.process_model_identifier,
+            process_model_display_name=processor.process_model_display_name,
+            properties=props,
+            parent=parent_id,
+            event_definition=serialized_task_spec.get("event_definition"),
+            error_message=error_message,
+            assigned_user_group_identifier=assigned_user_group_identifier,
+            potential_owner_usernames=potential_owner_usernames,
+        )
+
     ProcessInstanceService.create_process_instance = patched_create_process_instance  # type: ignore[assignment]
     ProcessInstanceService.complete_form_task = patched_complete_form_task
+    ProcessInstanceService.spiff_task_to_api_task = patched_spiff_task_to_api_task
     ProcessInstanceService.update_form_task_data = patched_update_form_task_data
     ProcessInstanceService.run_process_instance_with_processor = patched_run_process_instance_with_processor
     _PATCHED = True

--- a/m8flow-backend/src/m8flow_backend/services/spiff_timer_refresh_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/spiff_timer_refresh_patch.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from SpiffWorkflow.bpmn.specs.mixins.events.event_types import CatchingEvent
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.util.task import TaskState
+
+_PATCHED = False
+
+
+def apply() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    def patched_refresh_waiting_tasks(
+        self: BpmnWorkflow,
+        will_refresh_task: Callable[[Any], None] | None = None,
+        did_refresh_task: Callable[[Any], None] | None = None,
+    ) -> None:
+        """Restore waiting-event refresh behavior removed in newer SpiffWorkflow versions.
+
+        spiffworkflow-backend still expects this workflow hook to revisit WAITING catching
+        events so due timers can transition to READY. Newer SpiffWorkflow releases made the
+        method a no-op, which leaves timer catch events stuck in WAITING forever.
+        """
+
+        waiting_tasks = self.get_tasks(state=TaskState.WAITING, spec_class=CatchingEvent)
+        for task in waiting_tasks:
+            if will_refresh_task is not None:
+                will_refresh_task(task)
+            task.task_spec._update(task)
+            if did_refresh_task is not None:
+                did_refresh_task(task)
+
+    BpmnWorkflow.refresh_waiting_tasks = patched_refresh_waiting_tasks
+    _PATCHED = True

--- a/m8flow-backend/src/m8flow_backend/services/tenant_scoping_patch.py
+++ b/m8flow-backend/src/m8flow_backend/services/tenant_scoping_patch.py
@@ -369,10 +369,18 @@ def _set_postgres_tenant_context(session: Session, transaction: Any, connection:
         tenant_id = _resolve_tenant_id_for_db()
     except RuntimeError:
         return
-    connection.exec_driver_sql(
-        "SET LOCAL app.current_tenant = %s",
-        (tenant_id,),
-    )
+
+    raw_connection = getattr(connection, "connection", None)
+    driver_connection = getattr(raw_connection, "driver_connection", raw_connection)
+    if driver_connection is None:
+        connection.exec_driver_sql("SET LOCAL app.current_tenant = %s", (tenant_id,))
+        return
+
+    cursor = driver_connection.cursor()
+    try:
+        cursor.execute("SET LOCAL app.current_tenant = %s", (tenant_id,))
+    finally:
+        cursor.close()
 
 
 _SCOPING_LISTENER_REGISTERED = False

--- a/m8flow-backend/src/m8flow_backend/startup/patch_registry.py
+++ b/m8flow-backend/src/m8flow_backend/startup/patch_registry.py
@@ -125,6 +125,10 @@ POST_APP_CORE_PATCH_SPECS: tuple[PatchSpec, ...] = (
         minimum_phase=BootPhase.APP_CREATED,
     ),
     PatchSpec(
+        target="m8flow_backend.services.spiff_timer_refresh_patch:apply",
+        minimum_phase=BootPhase.APP_CREATED,
+    ),
+    PatchSpec(
         target="m8flow_backend.services.logging_service_patch:apply",
         minimum_phase=BootPhase.APP_CREATED,
     ),

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_celery_worker_runtime.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_celery_worker_runtime.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from m8flow_backend.services.celery_worker_runtime import cleanup_scoped_session
+from m8flow_backend.services.celery_worker_runtime import reset_engine_for_worker_process
+from m8flow_backend.services.celery_worker_runtime import tenant_id_for_process_instance
+
+
+class FakeResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar(self):
+        return self.value
+
+
+class FakeConnection:
+    def __init__(self, value):
+        self.value = value
+        self.calls: list[tuple[str, dict[str, int]]] = []
+
+    def execute(self, statement, params):
+        self.calls.append((str(statement), params))
+        return FakeResult(self.value)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeEngine:
+    def __init__(self, value):
+        self.connection = FakeConnection(value)
+
+    def connect(self):
+        return self.connection
+
+
+class FakeScopedSession:
+    def __init__(self, *, fail_rollback: bool = False, fail_remove: bool = False) -> None:
+        self.fail_rollback = fail_rollback
+        self.fail_remove = fail_remove
+        self.calls: list[str] = []
+
+    def rollback(self) -> None:
+        self.calls.append("rollback")
+        if self.fail_rollback:
+            raise RuntimeError("rollback failed")
+
+    def remove(self) -> None:
+        self.calls.append("remove")
+        if self.fail_remove:
+            raise RuntimeError("remove failed")
+
+
+class FakeEngineWithDispose:
+    def __init__(self, *, fail_dispose: bool = False) -> None:
+        self.fail_dispose = fail_dispose
+        self.dispose_calls = 0
+
+    def dispose(self) -> None:
+        self.dispose_calls += 1
+        if self.fail_dispose:
+            raise RuntimeError("dispose failed")
+
+
+def test_tenant_id_for_process_instance_uses_engine_connection() -> None:
+    engine = FakeEngine("tenant-a")
+
+    tenant_id = tenant_id_for_process_instance(engine, 42)
+
+    assert tenant_id == "tenant-a"
+    assert engine.connection.calls == [
+        ("SELECT m8f_tenant_id FROM process_instance WHERE id = :process_instance_id", {"process_instance_id": 42})
+    ]
+
+
+def test_tenant_id_for_process_instance_returns_none_for_missing_value() -> None:
+    engine = FakeEngine(None)
+
+    tenant_id = tenant_id_for_process_instance(engine, 42)
+
+    assert tenant_id is None
+
+
+def test_cleanup_scoped_session_rolls_back_and_removes() -> None:
+    session = FakeScopedSession()
+
+    cleanup_scoped_session(session)
+
+    assert session.calls == ["rollback", "remove"]
+
+
+def test_cleanup_scoped_session_still_removes_after_rollback_failure() -> None:
+    session = FakeScopedSession(fail_rollback=True)
+
+    cleanup_scoped_session(session)
+
+    assert session.calls == ["rollback", "remove"]
+
+
+def test_cleanup_scoped_session_swallows_remove_failure() -> None:
+    session = FakeScopedSession(fail_remove=True)
+
+    cleanup_scoped_session(session)
+
+    assert session.calls == ["rollback", "remove"]
+
+
+def test_reset_engine_for_worker_process_cleans_session_and_disposes_engine() -> None:
+    session = FakeScopedSession()
+    engine = FakeEngineWithDispose()
+
+    reset_engine_for_worker_process(engine, session)
+
+    assert session.calls == ["rollback", "remove"]
+    assert engine.dispose_calls == 1
+
+
+def test_reset_engine_for_worker_process_swallows_dispose_failure() -> None:
+    session = FakeScopedSession()
+    engine = FakeEngineWithDispose(fail_dispose=True)
+
+    reset_engine_for_worker_process(engine, session)
+
+    assert session.calls == ["rollback", "remove"]
+    assert engine.dispose_calls == 1

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_postgres_tenant_context_patch.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_postgres_tenant_context_patch.py
@@ -14,13 +14,26 @@ class FakeDialect:
         self.name = name
 
 
+class FakeCursor:
+    def __init__(self, owner: "FakeConnection") -> None:
+        self.owner = owner
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.owner.calls.append((sql, params))
+
+    def close(self) -> None:
+        self.owner.close_calls += 1
+
+
 class FakeConnection:
     def __init__(self, dialect_name: str) -> None:
         self.dialect = FakeDialect(dialect_name)
         self.calls: list[tuple[str, tuple | None]] = []
+        self.connection = self
+        self.close_calls = 0
 
-    def exec_driver_sql(self, sql: str, params: tuple | None = None) -> None:
-        self.calls.append((sql, params))
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
 
 
 def test_postgres_sets_tenant_context_from_request() -> None:
@@ -33,6 +46,7 @@ def test_postgres_sets_tenant_context_from_request() -> None:
         tenant_scoping_patch._set_postgres_tenant_context(None, None, connection)
 
     assert connection.calls == [("SET LOCAL app.current_tenant = %s", ("tenant-a",))]
+    assert connection.close_calls == 1
 
 
 def test_postgres_sets_tenant_context_from_background() -> None:
@@ -45,6 +59,7 @@ def test_postgres_sets_tenant_context_from_background() -> None:
         reset_context_tenant_id(token)
 
     assert connection.calls == [("SET LOCAL app.current_tenant = %s", ("tenant-b",))]
+    assert connection.close_calls == 1
 
 
 def test_postgres_missing_tenant_defaults_to_default_when_allowed(monkeypatch) -> None:
@@ -54,6 +69,7 @@ def test_postgres_missing_tenant_defaults_to_default_when_allowed(monkeypatch) -
     tenant_scoping_patch._set_postgres_tenant_context(None, None, connection)
 
     assert connection.calls == [("SET LOCAL app.current_tenant = %s", ("default",))]
+    assert connection.close_calls == 1
 
 
 def test_postgres_missing_tenant_uses_default() -> None:
@@ -65,6 +81,7 @@ def test_postgres_missing_tenant_uses_default() -> None:
     tenant_scoping_patch._set_postgres_tenant_context(None, None, connection)
 
     assert connection.calls == [("SET LOCAL app.current_tenant = %s", (default_id,))]
+    assert connection.close_calls == 1
 
 
 def test_non_postgres_does_nothing() -> None:
@@ -74,3 +91,4 @@ def test_non_postgres_does_nothing() -> None:
     tenant_scoping_patch._set_postgres_tenant_context(None, None, connection)
 
     assert connection.calls == []
+    assert connection.close_calls == 0

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_process_instance_service_patch.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_process_instance_service_patch.py
@@ -746,3 +746,239 @@ def test_apply_preflights_queued_form_submissions_before_returning(monkeypatch) 
             "tasks_that_have_been_seen": set(),
         }
     ]
+
+
+def test_safe_potential_owner_usernames_falls_back_and_skips_invalid_users(monkeypatch) -> None:
+    warning_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        process_instance_service_patch,
+        "current_app",
+        SimpleNamespace(logger=SimpleNamespace(warning=lambda *args: warning_calls.append(args))),
+    )
+
+    human_task = SimpleNamespace(
+        id=77,
+        task_id="task-guid-77",
+        potential_owners=[
+            SimpleNamespace(id=10, email=None, username="manager", display_name="Manager", service_id="svc-10"),
+            SimpleNamespace(id=11, email="approver@example.com", username="approver", display_name=None, service_id="svc-11"),
+            SimpleNamespace(id=12, email="   ", username="manager", display_name="Duplicate", service_id="svc-12"),
+            SimpleNamespace(id=13, email=None, username=None, display_name=None, service_id=None),
+        ],
+    )
+
+    result = process_instance_service_patch._safe_potential_owner_usernames(human_task)
+
+    assert result == "manager,approver@example.com"
+    assert warning_calls == [
+        (
+            "Skipping potential owner with no usable identifier for human_task id=%s task_id=%s user_id=%s",
+            77,
+            "task-guid-77",
+            13,
+        )
+    ]
+
+
+def test_apply_spiff_task_to_api_task_falls_back_when_email_is_missing(monkeypatch) -> None:
+    fake_service_module = ModuleType("spiffworkflow_backend.services.process_instance_service")
+    fake_processor_module = ModuleType("spiffworkflow_backend.services.process_instance_processor")
+    fake_queue_module = ModuleType("spiffworkflow_backend.services.process_instance_queue_service")
+    fake_migrator_module = ModuleType("spiffworkflow_backend.data_migrations.process_instance_migrator")
+    fake_db_module = ModuleType("spiffworkflow_backend.models.db")
+    fake_workflow_execution_module = ModuleType("spiffworkflow_backend.services.workflow_execution_service")
+    fake_error_module = ModuleType("spiffworkflow_backend.exceptions.error")
+    fake_group_module = ModuleType("spiffworkflow_backend.models.group")
+    fake_human_task_module = ModuleType("spiffworkflow_backend.models.human_task")
+    fake_event_module = ModuleType("spiffworkflow_backend.models.process_instance_event")
+    fake_task_module = ModuleType("spiffworkflow_backend.models.task")
+    fake_authorization_module = ModuleType("spiffworkflow_backend.services.authorization_service")
+    fake_spec_file_service_module = ModuleType("spiffworkflow_backend.services.spec_file_service")
+    fake_task_state_module = ModuleType("SpiffWorkflow.util.task")
+
+    class FakeTaskRunnability:
+        unknown_if_ready_tasks = "unknown_if_ready_tasks"
+
+    class FakeTaskState:
+        @staticmethod
+        def get_name(_state) -> str:
+            return "READY"
+
+    class FakeHumanTaskAlreadyCompletedError(Exception):
+        pass
+
+    class FakeHumanTaskNotFoundError(Exception):
+        pass
+
+    class FakeUserDoesNotHaveAccessToTaskError(Exception):
+        pass
+
+    class FakeProcessInstanceProcessor:
+        @classmethod
+        def get_tasks_with_data(cls, _bpmn_process_instance):
+            return []
+
+    class FakeProcessInstanceQueueService:
+        @staticmethod
+        def dequeued(_process_instance):
+            raise AssertionError("dequeued should not be called in this test")
+
+    class FakeProcessInstanceMigrator:
+        @staticmethod
+        def run(_process_instance) -> None:
+            return None
+
+    class FakeDbSession:
+        def refresh(self, _process_instance) -> None:
+            return None
+
+    class FakeTask:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+            self.potential_owner_usernames = kwargs.get("potential_owner_usernames")
+            self.assigned_user_group_identifier = kwargs.get("assigned_user_group_identifier")
+            self.can_complete = kwargs.get("can_complete")
+
+    class FakeAuthorizationService:
+        @staticmethod
+        def assert_user_can_complete_task(_process_instance_id, _task_guid, _user) -> None:
+            raise FakeUserDoesNotHaveAccessToTaskError()
+
+    fake_human_task = SimpleNamespace(
+        lane_assignment_id=None,
+        potential_owners=[
+            SimpleNamespace(id=91, email=None, username="reviewer", display_name="Reviewer", service_id="svc-91"),
+            SimpleNamespace(id=92, email="approver@example.com", username="approver", display_name="Approver", service_id="svc-92"),
+        ],
+    )
+
+    class FakeHumanTaskQuery:
+        def filter_by(self, **kwargs):
+            assert kwargs == {"task_id": "task-guid-1"}
+            return SimpleNamespace(first=lambda: fake_human_task)
+
+    class FakeHumanTaskModel:
+        query = FakeHumanTaskQuery()
+
+    class FakeGroupQuery:
+        def filter_by(self, **kwargs):
+            return SimpleNamespace(first=lambda: None)
+
+    class FakeGroupModel:
+        query = FakeGroupQuery()
+
+    class FakeEventQuery:
+        def filter_by(self, **kwargs):
+            assert kwargs == {"task_guid": "task-guid-1", "event_type": "task_failed"}
+            return SimpleNamespace(first=lambda: None)
+
+    class FakeProcessInstanceEventModel:
+        query = FakeEventQuery()
+
+    class FakeProcessInstanceEventType:
+        task_failed = SimpleNamespace(value="task_failed")
+
+    class FakeSpecFileService:
+        @staticmethod
+        def get_data(*_args, **_kwargs):
+            raise AssertionError("SpecFileService.get_data should not be called in this test")
+
+    class FakeProcessInstanceService:
+        @staticmethod
+        def create_process_instance(*_args, **_kwargs):
+            return (SimpleNamespace(id=0, m8f_tenant_id=None), None)
+
+        @staticmethod
+        def schedule_next_process_model_cycle(*_args, **_kwargs):
+            return None
+
+        @staticmethod
+        def can_optimistically_skip(_processor, _status_value):
+            return False
+
+        @classmethod
+        def update_form_task_data(cls, _process_instance, _spiff_task, _data, _user):
+            return None
+
+        @staticmethod
+        def spiff_task_to_api_task(_processor, _spiff_task):
+            raise TypeError("sequence item 0: expected str instance, NoneType found")
+
+    fake_service_module.ProcessInstanceService = FakeProcessInstanceService
+    fake_processor_module.ProcessInstanceProcessor = FakeProcessInstanceProcessor
+    fake_queue_module.ProcessInstanceQueueService = FakeProcessInstanceQueueService
+    fake_migrator_module.ProcessInstanceMigrator = FakeProcessInstanceMigrator
+    fake_db_module.db = SimpleNamespace(session=FakeDbSession())
+    fake_workflow_execution_module.TaskRunnability = FakeTaskRunnability
+    fake_error_module.HumanTaskAlreadyCompletedError = FakeHumanTaskAlreadyCompletedError
+    fake_error_module.HumanTaskNotFoundError = FakeHumanTaskNotFoundError
+    fake_error_module.UserDoesNotHaveAccessToTaskError = FakeUserDoesNotHaveAccessToTaskError
+    fake_group_module.GroupModel = FakeGroupModel
+    fake_human_task_module.HumanTaskModel = FakeHumanTaskModel
+    fake_event_module.ProcessInstanceEventModel = FakeProcessInstanceEventModel
+    fake_event_module.ProcessInstanceEventType = FakeProcessInstanceEventType
+    fake_task_module.Task = FakeTask
+    fake_authorization_module.AuthorizationService = FakeAuthorizationService
+    fake_spec_file_service_module.SpecFileService = FakeSpecFileService
+    fake_task_state_module.TaskState = FakeTaskState
+
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.process_instance_service", fake_service_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.process_instance_processor", fake_processor_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.process_instance_queue_service", fake_queue_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.data_migrations.process_instance_migrator", fake_migrator_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.models.db", fake_db_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.workflow_execution_service", fake_workflow_execution_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.exceptions.error", fake_error_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.models.group", fake_group_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.models.human_task", fake_human_task_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.models.process_instance_event", fake_event_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.models.task", fake_task_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.authorization_service", fake_authorization_module)
+    monkeypatch.setitem(sys.modules, "spiffworkflow_backend.services.spec_file_service", fake_spec_file_service_module)
+    monkeypatch.setitem(sys.modules, "SpiffWorkflow.util.task", fake_task_state_module)
+    monkeypatch.setattr(process_instance_service_patch, "_PATCHED", False)
+    monkeypatch.setattr(
+        process_instance_service_patch,
+        "current_app",
+        SimpleNamespace(
+            logger=SimpleNamespace(
+                info=lambda *args, **kwargs: None,
+                warning=lambda *args, **kwargs: None,
+            )
+        ),
+    )
+
+    process_instance_service_patch.apply()
+
+    processor = SimpleNamespace(
+        process_instance_model=SimpleNamespace(id=17),
+        process_model_identifier="two-step-approval",
+        process_model_display_name="Two Step Approval",
+        serialize_task_spec=lambda _task_spec: {"event_definition": None},
+    )
+    spiff_task = SimpleNamespace(
+        id="task-guid-1",
+        state=8,
+        parent=None,
+        task_spec=SimpleNamespace(
+            description="User Task",
+            bpmn_id="Activity_Review",
+            bpmn_name="Review Request",
+            lane="Manager",
+            extensions={},
+            _wf_spec=SimpleNamespace(name="Process_1"),
+        ),
+    )
+
+    app = Flask(__name__)
+    with app.app_context():
+        from flask import g
+
+        g.user = SimpleNamespace(id=501)
+        result = FakeProcessInstanceService.spiff_task_to_api_task(processor, spiff_task)
+
+    assert isinstance(result, FakeTask)
+    assert result.potential_owner_usernames == "reviewer,approver@example.com"
+    assert result.assigned_user_group_identifier is None
+    assert result.can_complete is False

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_spiff_timer_refresh_patch.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_spiff_timer_refresh_patch.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from SpiffWorkflow.bpmn.specs.mixins.events.event_types import CatchingEvent
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.util.task import TaskState
+
+from m8flow_backend.services import spiff_timer_refresh_patch
+
+
+class FakeTaskSpec:
+    def __init__(self) -> None:
+        self.updated_tasks: list[FakeTask] = []
+
+    def _update(self, task: "FakeTask") -> None:
+        self.updated_tasks.append(task)
+
+
+class FakeTask:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.task_spec = FakeTaskSpec()
+
+
+class FakeWorkflow:
+    def __init__(self, tasks: list[FakeTask]) -> None:
+        self.tasks = tasks
+        self.get_tasks_calls: list[tuple[TaskState, type]] = []
+
+    def get_tasks(self, *, state: TaskState, spec_class: type) -> list[FakeTask]:
+        self.get_tasks_calls.append((state, spec_class))
+        return list(self.tasks)
+
+
+def test_refresh_waiting_tasks_updates_waiting_catching_events() -> None:
+    spiff_timer_refresh_patch.apply()
+
+    task_one = FakeTask("one")
+    task_two = FakeTask("two")
+    workflow = FakeWorkflow([task_one, task_two])
+    refreshed: list[str] = []
+    completed: list[str] = []
+
+    BpmnWorkflow.refresh_waiting_tasks(
+        workflow,
+        will_refresh_task=lambda task: refreshed.append(task.label),
+        did_refresh_task=lambda task: completed.append(task.label),
+    )
+
+    assert workflow.get_tasks_calls == [(TaskState.WAITING, CatchingEvent)]
+    assert refreshed == ["one", "two"]
+    assert completed == ["one", "two"]
+    assert task_one.task_spec.updated_tasks == [task_one]
+    assert task_two.task_spec.updated_tasks == [task_two]


### PR DESCRIPTION
## JIRA Ticket

https://aottech.atlassian.net/browse/M8F-279

## Description


This PR hardens M8Flow Celery execution for tenant-aware background tasks and restores timer progression compatibility with the current SpiffWorkflow runtime.

### What changed

#### 1. Rebrand Celery task names to M8Flow-owned task IDs

M8Flow now exposes process-instance Celery tasks under M8Flow-owned names instead of upstream `spiffworkflow_backend.*` names:

- `M8FLOW_CELERY_TASK_PROCESS_INSTANCE_RUN`
- `M8FLOW_CELERY_TASK_EVENT_NOTIFIER`

This keeps task names and Flower UI branding aligned with M8Flow without modifying upstream SpiffWorkflow code.

#### 2. Move tenant-context ownership into the M8Flow wrapper tasks

The M8Flow wrapper tasks now set and clear tenant context around the upstream raw task execution.

This was necessary because once the worker is dispatching the new M8Flow task names, those tasks are no longer just upstream Celery tasks. They are M8Flow wrappers, so tenant lifecycle must be owned at that wrapper boundary.

The wrapper task flow now:
- cleans up scoped ORM session state before execution
- resolves tenant from task headers or `process_instance_id`
- sets tenant context for the duration of the task
- delegates to the upstream `.run()` implementation
- clears tenant context and session state afterward

#### 3. Keep worker signal hooks as compatibility/fallback logic

`set_tenant_context_for_task()` and `clear_tenant_context_for_task()` in `celery_worker.py` were updated to skip the two M8Flow wrapper task names.

This prevents double tenant setup/cleanup for:
- `M8FLOW_CELERY_TASK_PROCESS_INSTANCE_RUN`
- `M8FLOW_CELERY_TASK_EVENT_NOTIFIER`

The worker hooks still remain in place for:
- legacy upstream task names that may already be queued
- fallback handling outside the M8Flow wrapper path
- per-task scoped-session cleanup in prefork workers

#### 4. Harden Celery worker database/session handling

Celery worker runtime handling was tightened to reduce session/connection leakage across prefork worker processes.

This includes:
- resetting inherited DB connections when worker child processes start
- cleaning up scoped ORM session state between tasks
- resolving tenant IDs for `process_instance_id` using a direct engine query instead of the shared scoped ORM session

#### 5. Restore timer wake-up behavior for current SpiffWorkflow runtime

A compatibility patch was added for timer catch events because the installed SpiffWorkflow version no longer refreshes waiting timer tasks in the way `spiffworkflow-backend` expects.

The patch restores the expected behavior by revisiting waiting timer-catching tasks and forcing their state update, which allows due timers to advance the process instance correctly.

### Why this was needed

These changes address two related problems:

1. Tenant-aware Celery execution was no longer safe once M8Flow introduced wrapper task names.
   Without changing the worker hooks, tenant context could be applied twice or session state could leak across Celery tasks.

2. Timer-based process models could remain stuck even after Celery executed, because the current SpiffWorkflow runtime no longer refreshes waiting timer events the way upstream backend code expects.

### Behavior after this PR

- M8Flow-branded Celery task names are used consistently.
- Tenant context is owned by the M8Flow task wrappers for the main process-instance Celery tasks.
- Legacy queued upstream task names still remain compatible.
- Scoped DB/session state is cleaned up more reliably in Celery workers.
- Due timer catch events advance to the next task as expected.

### Files changed

- `m8flow-backend/src/m8flow_backend/background_processing/__init__.py`
- `m8flow-backend/src/m8flow_backend/background_processing/celery_worker.py`
- `m8flow-backend/src/m8flow_backend/background_processing/celery_tasks/process_instance_task.py`
- `m8flow-backend/src/m8flow_backend/services/celery_worker_runtime.py`
- `m8flow-backend/src/m8flow_backend/services/spiff_timer_refresh_patch.py`
- `m8flow-backend/src/m8flow_backend/startup/patch_registry.py`


## Type

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [x] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

Validated with unit coverage around:
- Celery worker runtime/session handling
- tenant context behavior for Celery tasks
- startup patch registration
- timer refresh compatibility

Also verified against the Docker containers by rebuilding/restarting the backend and Celery worker and running a fresh timer-based process instance to confirm the timer advanced to the expected ready/user-input state.



## Related Issues

Closes #

