### PR TITLE
fixed the smtp notification

### DIFF
--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -2281,6 +2281,39 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /notification-smtp-status:
+    get:
+      operationId: m8flow_backend.routes.notification_smtp_controller.notification_smtp_status
+      summary: Check SMTP configuration status for external form notifications
+      description: >
+        Returns which NATS_SMTP_* secret keys are configured for the current tenant.
+        Used by the frontend to surface warnings when SMTP is not set up.
+        Never returns secret values, only presence booleans.
+      tags:
+        - Notifications
+      responses:
+        "200":
+          description: SMTP configuration status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  configured:
+                    type: boolean
+                  required_keys:
+                    type: array
+                    items:
+                      type: string
+                  optional_keys:
+                    type: array
+                    items:
+                      type: string
+                  keys_present:
+                    type: object
+                    additionalProperties:
+                      type: boolean
+
   /connectors-grouped:
     get:
       operationId: m8flow_backend.routes.connectors_controller.connectors_grouped

--- a/m8flow-backend/src/m8flow_backend/config/permissions/m8flow.yml
+++ b/m8flow-backend/src/m8flow_backend/config/permissions/m8flow.yml
@@ -236,6 +236,10 @@ permissions:
     groups: ["everybody"]
     actions: [read]
     uri: /m8flow/mcp-connection
+  read-notification-smtp-status:
+    groups: ["everybody"]
+    actions: [read]
+    uri: /m8flow/notification-smtp-status
   read-data-stores:
     groups: ["viewer", "super-admin"]
     actions: [read]

--- a/m8flow-backend/src/m8flow_backend/models/external_form_request.py
+++ b/m8flow-backend/src/m8flow_backend/models/external_form_request.py
@@ -20,6 +20,7 @@ class ExternalFormRequestStatus(SpiffEnum):
     failed = "failed"
     expired = "expired"
     superseded = "superseded"
+    smtp_not_configured = "smtp_not_configured"
 
 
 # Statuses for which the secure link may still be used to submit the form.

--- a/m8flow-backend/src/m8flow_backend/routes/connectors_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/connectors_controller.py
@@ -144,6 +144,20 @@ CONNECTOR_METADATA: dict[str, ConnectorMeta] = {
             {"id": "api_key", "secretKey": "STRIPE_KEY", "label": "API Key", "type": "password", "required": True},
         ],
     },
+    "nats_smtp": {
+        "name": "Notification Email (SMTP)",
+        "description": "SMTP settings for external form notification emails",
+        "icon": "email",
+        "configFields": [
+            {"id": "host", "secretKey": "NATS_SMTP_HOST", "label": "SMTP Host", "type": "text", "required": True},
+            {"id": "port", "secretKey": "NATS_SMTP_PORT", "label": "SMTP Port", "type": "text", "required": False, "format": "port"},
+            {"id": "username", "secretKey": "NATS_SMTP_USERNAME", "label": "Username", "type": "text", "required": False},
+            {"id": "password", "secretKey": "NATS_SMTP_PASSWORD", "label": "Password", "type": "password", "required": False},
+            {"id": "from_email", "secretKey": "NATS_SMTP_FROM_EMAIL", "label": "From Email", "type": "text", "required": True, "format": "email"},
+            {"id": "starttls", "secretKey": "NATS_SMTP_STARTTLS", "label": "Use STARTTLS", "type": "text", "required": False, "helpText": "true / false"},
+            {"id": "ssl", "secretKey": "NATS_SMTP_SSL", "label": "Use SSL", "type": "text", "required": False, "helpText": "true / false"},
+        ],
+    },
 }
 
 _UPPERCASE_ABBREVS = {"HTTP", "HTML", "SMTP", "API", "URL", "SQL", "SSH", "FTP", "AWS", "GCP"}
@@ -274,4 +288,33 @@ def connectors_grouped() -> flask.wrappers.Response:
         )
 
     result = sorted(groups.values(), key=lambda g: g["name"].lower())
+
+    # Inject virtual connectors that have configFields in CONNECTOR_METADATA but
+    # no runtime operations from the connector proxy (e.g. nats_smtp). They
+    # appear in the Connectors page so admins can configure their secrets.
+    seen_keys = {g["id"] for g in result}
+    for connector_key, meta in CONNECTOR_METADATA.items():
+        if connector_key in seen_keys:
+            continue
+        config_fields = _valid_config_fields(
+            connector_key, meta.get("configFields", [])
+        )
+        if not config_fields:
+            continue
+        virtual_entry: dict[str, Any] = {
+            "id": connector_key,
+            "name": meta.get("name", _humanize_connector_key(connector_key)),
+            "description": meta.get("description", ""),
+            "status": "available",
+            "icon": meta.get("icon", "extension"),
+            "operationCount": 0,
+            "operations": [],
+            "configFields": config_fields,
+        }
+        docs_url = meta.get("docsUrl")
+        if docs_url:
+            virtual_entry["docsUrl"] = docs_url
+        result.append(virtual_entry)
+
+    result.sort(key=lambda g: g["name"].lower())
     return make_response(jsonify(result), 200)

--- a/m8flow-backend/src/m8flow_backend/routes/notification_smtp_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/notification_smtp_controller.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from m8flow_backend.helpers.response_helper import handle_api_errors, success_response
+
+
+@handle_api_errors
+def notification_smtp_status() -> tuple:
+    """Return which NATS_SMTP_* secret keys are configured for the active tenant.
+
+    The response carries only per-key presence booleans and the overall
+    ``configured`` flag — secret values are never included. The frontend uses
+    this to surface a warning banner when the required SMTP secrets are missing.
+    """
+    from m8flow_backend.services.external_form_notification_service import (
+        ExternalFormNotificationService,
+    )
+
+    status = ExternalFormNotificationService.check_smtp_configured()
+    return success_response(status, 200)

--- a/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
@@ -224,6 +224,27 @@ class ExternalFormNotificationService:
             "ssl": _is_truthy(cls._read_tenant_secret(SMTP_SECRET_KEYS["ssl"])),
         }
 
+    @classmethod
+    def check_smtp_configured(cls) -> dict[str, Any]:
+        """Check which NATS_SMTP_* secret keys are configured for the current tenant.
+
+        Returns a dict with an overall 'configured' boolean, the required/optional key
+        names, and per-key presence booleans. Never returns secret values."""
+        keys_present: dict[str, bool] = {}
+        for _friendly, secret_key in SMTP_SECRET_KEYS.items():
+            keys_present[secret_key] = cls._read_tenant_secret(secret_key) is not None
+
+        host_ok = keys_present.get(SMTP_SECRET_KEYS["host"], False)
+        from_ok = keys_present.get(SMTP_SECRET_KEYS["from_email"], False)
+        return {
+            "configured": host_ok and from_ok,
+            "required_keys": [SMTP_SECRET_KEYS["host"], SMTP_SECRET_KEYS["from_email"]],
+            "optional_keys": [
+                v for k, v in SMTP_SECRET_KEYS.items() if k not in ("host", "from_email")
+            ],
+            "keys_present": keys_present,
+        }
+
     @staticmethod
     def send_email(settings: dict[str, Any], to_email: str, subject: str, text_body: str, html_body: str) -> None:
         message = EmailMessage()
@@ -261,12 +282,31 @@ class ExternalFormNotificationService:
             return "skipped:unknown_reference"
         smtp_settings = cls.resolve_smtp_settings()
         if smtp_settings is None:
-            LOGGER.warning(
-                "external-form-notify: tenant %s has no SMTP secrets configured; leaving request id=%s pending",
+            now = int(time.time())
+            db.session.execute(
+                sa_update(ExternalFormRequestModel)
+                .where(
+                    ExternalFormRequestModel.id == row.id,
+                    ExternalFormRequestModel.status.in_(CLAIMABLE_STATUSES),
+                )
+                .values(
+                    status=ExternalFormRequestStatus.smtp_not_configured.value,
+                    attempts=ExternalFormRequestModel.attempts + 1,
+                    updated_at_in_seconds=now,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            db.session.commit()
+            LOGGER.error(
+                "external-form-notify: tenant %s has no SMTP secrets configured; "
+                "request id=%s moved to terminal smtp_not_configured. "
+                "Required secrets: %s, %s",
                 row.m8f_tenant_id,
                 row.id,
+                SMTP_SECRET_KEYS["host"],
+                SMTP_SECRET_KEYS["from_email"],
             )
-            return "skipped:smtp_unconfigured"
+            return "failed:smtp_not_configured"
         now = int(time.time())
         if row.expires_at_in_seconds is not None and row.expires_at_in_seconds < now:
             return "skipped:expired"

--- a/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
@@ -298,13 +298,11 @@ class ExternalFormNotificationService:
             )
             db.session.commit()
             LOGGER.error(
-                "external-form-notify: tenant %s has no SMTP secrets configured; "
+                "external-form-notify: tenant %s has no SMTP configuration keys set; "
                 "request id=%s moved to terminal smtp_not_configured. "
-                "Required secrets: %s, %s",
+                "Required keys: NATS_SMTP_HOST, NATS_SMTP_FROM_EMAIL",
                 row.m8f_tenant_id,
                 row.id,
-                SMTP_SECRET_KEYS["host"],
-                SMTP_SECRET_KEYS["from_email"],
             )
             return "failed:smtp_not_configured"
         now = int(time.time())

--- a/m8flow-backend/tests/unit/m8flow_backend/routes/test_connectors_controller.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/routes/test_connectors_controller.py
@@ -90,3 +90,19 @@ def test_effective_secret_key_falls_back_to_derived_name():
         effective_secret_key("widget", {"id": "api_key", "label": "x", "type": "text", "required": True})
         == "widget_api_key"
     )
+
+
+def test_connectors_grouped_injects_nats_smtp_virtual_connector():
+    """Virtual connectors like nats_smtp must appear in the grouped list even with 0 operations."""
+    groups = _call_grouped([])
+    by_id = {g["id"]: g for g in groups}
+
+    assert "nats_smtp" in by_id
+    nats_smtp = by_id["nats_smtp"]
+    assert nats_smtp["name"] == "Notification Email (SMTP)"
+    assert nats_smtp["operationCount"] == 0
+    assert "configFields" in nats_smtp
+    secret_keys = {f["secretKey"] for f in nats_smtp["configFields"]}
+    assert "NATS_SMTP_HOST" in secret_keys
+    assert "NATS_SMTP_FROM_EMAIL" in secret_keys
+

--- a/m8flow-backend/tests/unit/m8flow_backend/routes/test_notification_smtp_controller.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/routes/test_notification_smtp_controller.py
@@ -1,0 +1,77 @@
+"""Unit tests for notification_smtp_controller.
+
+Tests cover:
+- GET /notification-smtp-status returns 200 with SMTP configuration status dictionary.
+- ApiError mapping through handle_api_errors.
+"""
+from unittest.mock import patch
+import pytest
+from flask import Flask
+
+from spiffworkflow_backend.exceptions.api_error import ApiError
+from m8flow_backend.routes import notification_smtp_controller
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    return app
+
+
+class TestNotificationSmtpStatus:
+    def test_returns_status_with_200(self, app):
+        expected = {
+            "configured": True,
+            "required_keys": ["NATS_SMTP_HOST", "NATS_SMTP_FROM_EMAIL"],
+            "optional_keys": ["NATS_SMTP_PORT", "NATS_SMTP_USERNAME", "NATS_SMTP_PASSWORD", "NATS_SMTP_STARTTLS", "NATS_SMTP_SSL"],
+            "keys_present": {
+                "NATS_SMTP_HOST": True,
+                "NATS_SMTP_FROM_EMAIL": True,
+                "NATS_SMTP_PORT": True,
+            },
+        }
+        with patch(
+            "m8flow_backend.services.external_form_notification_service."
+            "ExternalFormNotificationService.check_smtp_configured",
+            return_value=expected,
+        ), app.test_request_context("/m8flow/notification-smtp-status"):
+            response = notification_smtp_controller.notification_smtp_status()
+
+        assert response.status_code == 200
+        assert response.get_json() == expected
+
+    def test_handles_api_error_gracefully(self, app):
+        with patch(
+            "m8flow_backend.services.external_form_notification_service."
+            "ExternalFormNotificationService.check_smtp_configured",
+            side_effect=ApiError(error_code="internal_error", message="Failed", status_code=500),
+        ), app.test_request_context("/m8flow/notification-smtp-status"):
+            response = notification_smtp_controller.notification_smtp_status()
+
+        assert response.status_code == 500
+
+
+class TestNotificationSmtpPermissions:
+    def test_permission_registered_for_everybody_in_m8flow_yml(self):
+        from pathlib import Path
+        import yaml
+
+        permissions_path = (
+            Path(__file__).resolve().parents[4]
+            / "src"
+            / "m8flow_backend"
+            / "config"
+            / "permissions"
+            / "m8flow.yml"
+        )
+        with open(permissions_path, encoding="utf-8") as fh:
+            config = yaml.safe_load(fh)
+        permissions = config["permissions"]
+
+        assert "read-notification-smtp-status" in permissions
+        grant = permissions["read-notification-smtp-status"]
+        assert grant["uri"] == "/m8flow/notification-smtp-status"
+        assert grant["actions"] == ["read"]
+        assert "everybody" in grant["groups"]
+

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
@@ -366,19 +366,22 @@ class TestNotify:
     def test_unknown_reference(self, app):
         assert ExternalFormNotificationService.notify("no-such-ref") == "skipped:unknown_reference"
 
-    def test_unconfigured_smtp_leaves_row_pending(self, app, tenant, alice, fake_smtp, smtp_secrets):
+    def test_unconfigured_smtp_marks_smtp_not_configured(self, app, tenant, alice, fake_smtp, smtp_secrets):
         smtp_secrets.clear()  # tenant has no SMTP secrets
         row = _create_request(tenant, alice)
 
-        assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:smtp_unconfigured"
-        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+        assert ExternalFormNotificationService.notify(row.reference_id) == "failed:smtp_not_configured"
+        row = _fresh(row.id)
+        assert row.status == ExternalFormRequestStatus.smtp_not_configured.value
+        assert row.attempts == 1
 
-    def test_missing_from_email_is_unconfigured(self, app, tenant, alice, fake_smtp, smtp_secrets):
+    def test_missing_from_email_is_smtp_not_configured(self, app, tenant, alice, fake_smtp, smtp_secrets):
         del smtp_secrets["NATS_SMTP_FROM_EMAIL"]  # host present but no sender address
         row = _create_request(tenant, alice)
 
-        assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:smtp_unconfigured"
-        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+        assert ExternalFormNotificationService.notify(row.reference_id) == "failed:smtp_not_configured"
+        row = _fresh(row.id)
+        assert row.status == ExternalFormRequestStatus.smtp_not_configured.value
 
     def test_expired_row_is_not_emailed(self, app, tenant, alice, fake_smtp, smtp_secrets):
         row = _create_request(tenant, alice, expires_at_in_seconds=int(time.time()) - 10)
@@ -449,3 +452,43 @@ class TestRenderEmail:
 
         assert "<script>" not in html_body
         assert "&amp;" in html_body
+
+
+class TestSmtpNotConfiguredSweep:
+    def _sweep_now(self):
+        return int(time.time()) + 1000
+
+    def test_smtp_not_configured_not_swept(self, app, tenant, alice, smtp_secrets):
+        smtp_secrets.clear()
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.notify(row.reference_id)
+
+        candidates = ExternalFormNotificationService.sweep_candidates(now=self._sweep_now())
+        assert candidates == []
+
+
+class TestCheckSmtpConfigured:
+    def test_returns_configured_true_when_required_keys_present(self, app, tenant, smtp_secrets):
+        result = ExternalFormNotificationService.check_smtp_configured()
+        assert result["configured"] is True
+        assert result["keys_present"]["NATS_SMTP_HOST"] is True
+        assert result["keys_present"]["NATS_SMTP_FROM_EMAIL"] is True
+
+    def test_returns_configured_false_when_host_missing(self, app, tenant, smtp_secrets):
+        del smtp_secrets["NATS_SMTP_HOST"]
+        result = ExternalFormNotificationService.check_smtp_configured()
+        assert result["configured"] is False
+        assert result["keys_present"]["NATS_SMTP_HOST"] is False
+
+    def test_returns_configured_false_when_all_missing(self, app, tenant, smtp_secrets):
+        smtp_secrets.clear()
+        result = ExternalFormNotificationService.check_smtp_configured()
+        assert result["configured"] is False
+        assert all(v is False for v in result["keys_present"].values())
+
+    def test_includes_required_and_optional_keys(self, app, tenant, smtp_secrets):
+        result = ExternalFormNotificationService.check_smtp_configured()
+        assert "NATS_SMTP_HOST" in result["required_keys"]
+        assert "NATS_SMTP_FROM_EMAIL" in result["required_keys"]
+        assert "NATS_SMTP_PORT" in result["optional_keys"]
+        assert "NATS_SMTP_USERNAME" in result["optional_keys"]

--- a/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js
@@ -1,5 +1,6 @@
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 import { SpiffExtensionTextInput } from 'bpmn-js-spiffworkflow/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionTextInput';
+import HttpService from '@spiffworkflow-frontend/services/HttpService';
 
 const LOW_PRIORITY = 500;
 
@@ -9,12 +10,60 @@ export const EXTERNAL_FORM_GROUP_ID = 'external_form_properties';
 // Upstream "Web Form (with Json Schemas)" group; we slot ours right after it.
 const JSON_SCHEMA_GROUP_ID = 'user_task_properties';
 
+let cachedSmtpStatus = null;
+let isFetchingSmtpStatus = false;
+
+export function fetchSmtpStatus() {
+  if (isFetchingSmtpStatus || cachedSmtpStatus !== null) return;
+  isFetchingSmtpStatus = true;
+  try {
+    HttpService.makeCallToBackend({
+      path: '/m8flow/notification-smtp-status',
+      successCallback: (data) => {
+        cachedSmtpStatus = data;
+        isFetchingSmtpStatus = false;
+      },
+      failureCallback: () => {
+        isFetchingSmtpStatus = false;
+      },
+    });
+  } catch (_e) {
+    isFetchingSmtpStatus = false;
+  }
+}
+
+export function setCachedSmtpStatusForTesting(status) {
+  cachedSmtpStatus = status;
+}
+
+export function getExternalFormDescription(translate) {
+  fetchSmtpStatus();
+  if (cachedSmtpStatus && cachedSmtpStatus.configured === false) {
+    const missing = Object.entries(cachedSmtpStatus.keys_present || {})
+      .filter(([, present]) => !present)
+      .map(([k]) => k)
+      .join(', ');
+    return translate(
+      `⚠️ Warning: Notification SMTP is not configured for this tenant (missing: ${missing || 'NATS_SMTP_HOST, NATS_SMTP_FROM_EMAIL'}). Assignees will not receive emails until configured in Configuration > Secrets or Connectors. When set, this user task uses an external form. Assignees are emailed a secure link to this URL. Clear the field to disable.`
+    );
+  }
+  if (cachedSmtpStatus && cachedSmtpStatus.configured === true) {
+    return translate(
+      '✓ Notification SMTP is configured. When set, this user task uses an external form. Assignees are emailed a secure link to this URL. Clear the field to disable.'
+    );
+  }
+  return translate(
+    'When set, this user task uses an external form. Assignees are emailed a secure link to this URL. Email delivery requires tenant SMTP secrets (NATS_SMTP_HOST, NATS_SMTP_FROM_EMAIL) to be configured in Configuration > Secrets or Connectors. Clear the field to disable.'
+  );
+}
+
 export default function ExternalFormPropertiesProvider(
   propertiesPanel,
   translate,
   moddle,
   commandStack
 ) {
+  fetchSmtpStatus();
   this.getGroups = function (element) {
     return function (groups) {
       if (is(element, 'bpmn:UserTask')) {
@@ -59,9 +108,7 @@ function createExternalFormGroup(element, translate, moddle, commandStack) {
         component: SpiffExtensionTextInput,
         name: EXTERNAL_FORM_URL_PROP,
         label: translate('External form URL'),
-        description: translate(
-          'When set, this user task uses an external form. Assignees are emailed a secure link to this URL. Clear the field to disable.'
-        ),
+        description: getExternalFormDescription(translate),
       },
     ],
   };

--- a/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts
@@ -64,6 +64,8 @@ describe('ExternalFormPropertiesProvider', () => {
     expect(urlEntry.moddle).toBe(moddle);
     expect(urlEntry.commandStack).toBe(commandStack);
     expect(typeof urlEntry.component).toBe('function');
+    expect(urlEntry.description).toContain('NATS_SMTP_HOST');
+    expect(urlEntry.description).toContain('NATS_SMTP_FROM_EMAIL');
   });
 
   it('does not add the group to non-user-task elements', () => {
@@ -110,5 +112,41 @@ describe('ExternalFormPropertiesProvider', () => {
     expect(groups[0]).toBe(existing);
     expect(groups[groups.length - 1].id).toBe(EXTERNAL_FORM_GROUP_ID);
     expect(groups).toHaveLength(2);
+  });
+
+  it('displays warning when SMTP status is unconfigured', async () => {
+    const { setCachedSmtpStatusForTesting } = await import(
+      './ExternalFormPropertiesProvider'
+    );
+    setCachedSmtpStatusForTesting({
+      configured: false,
+      required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+      keys_present: { NATS_SMTP_HOST: false, NATS_SMTP_FROM_EMAIL: false },
+    });
+
+    const { provider } = instantiate();
+    const groups = provider.getGroups(makeElement('bpmn:UserTask'))([]);
+    const [urlEntry] = groups[0].entries;
+
+    expect(urlEntry.description).toContain('Warning: Notification SMTP is not configured');
+    expect(urlEntry.description).toContain('NATS_SMTP_HOST');
+    expect(urlEntry.description).toContain('NATS_SMTP_FROM_EMAIL');
+  });
+
+  it('displays configured indicator when SMTP is configured', async () => {
+    const { setCachedSmtpStatusForTesting } = await import(
+      './ExternalFormPropertiesProvider'
+    );
+    setCachedSmtpStatusForTesting({
+      configured: true,
+      required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+      keys_present: { NATS_SMTP_HOST: true, NATS_SMTP_FROM_EMAIL: true },
+    });
+
+    const { provider } = instantiate();
+    const groups = provider.getGroups(makeElement('bpmn:UserTask'))([]);
+    const [urlEntry] = groups[0].entries;
+
+    expect(urlEntry.description).toContain('Notification SMTP is configured');
   });
 });

--- a/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx
+++ b/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx
@@ -12,6 +12,7 @@ export const useM8flowUriListForPermissions = () => {
       m8flowTemplateListPath: "/m8flow/templates",
       serviceTaskListPath: "/service-tasks",
       connectorsGroupedPath: "/m8flow/connectors-grouped",
+      notificationSmtpStatusPath: "/m8flow/notification-smtp-status",
       m8flowMcpConnectionPath: "/m8flow/mcp-connection",
       m8flowNatsTokensPath: "/m8flow/nats-tokens",
     };

--- a/m8flow-frontend/src/locales/en_us/translation.json
+++ b/m8flow-frontend/src/locales/en_us/translation.json
@@ -459,5 +459,9 @@
   "continuing_into_tenant": "Continuing into {{tenant}}...",
   "select_a_tenant": "Select a Tenant",
   "multi_tenant_choose_description": "Your account has access to more than one tenant. Choose the tenant you want to enter for this session.",
-  "owner": "Owner"
+  "owner": "Owner",
+  "smtp_notification_warning_title": "Notification SMTP Not Configured",
+  "smtp_notification_warning_body": "External form notification emails require SMTP secrets to be configured. Without them, notification emails will not be sent. Missing keys: {{keys}}",
+  "smtp_notification_configured": "Notification SMTP is configured",
+  "smtp_notification_status_loading": "Checking notification SMTP status…"
 }

--- a/m8flow-frontend/src/views/SecretList.test.tsx
+++ b/m8flow-frontend/src/views/SecretList.test.tsx
@@ -74,7 +74,19 @@ import HttpService from '../services/HttpService';
 
 function stubSecretsList() {
   vi.mocked(HttpService.makeCallToBackend).mockImplementation((opts: any) => {
-    opts.successCallback({
+    if (opts.path === '/m8flow/notification-smtp-status') {
+      opts.successCallback?.({
+        configured: true,
+        required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+        optional_keys: ['NATS_SMTP_PORT'],
+        keys_present: {
+          NATS_SMTP_HOST: true,
+          NATS_SMTP_FROM_EMAIL: true,
+        },
+      });
+      return;
+    }
+    opts.successCallback?.({
       results: [
         {
           id: 1,

--- a/m8flow-frontend/src/views/SecretList.test.tsx
+++ b/m8flow-frontend/src/views/SecretList.test.tsx
@@ -134,4 +134,70 @@ describe('SecretList', () => {
     );
     expect(screen.queryByTestId('secret-list-tenant-cell')).toBeNull();
   });
+
+  it('renders SMTP warning banner when notification SMTP is unconfigured', () => {
+    vi.mocked(HttpService.makeCallToBackend).mockImplementation((opts: any) => {
+      if (opts.path === '/m8flow/notification-smtp-status') {
+        opts.successCallback({
+          configured: false,
+          required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+          optional_keys: ['NATS_SMTP_PORT'],
+          keys_present: {
+            NATS_SMTP_HOST: false,
+            NATS_SMTP_FROM_EMAIL: false,
+          },
+        });
+      } else {
+        opts.successCallback({
+          results: [{ id: 1, key: 'api-key', username: 'editor' }],
+          pagination: { total: 1, pages: 1 },
+        });
+      }
+    });
+
+    renderList();
+    expect(screen.getByTestId('smtp-notification-warning')).toBeInTheDocument();
+    expect(screen.getByText('smtp_notification_warning_title')).toBeInTheDocument();
+  });
+
+  it('does not render SMTP warning banner when notification SMTP is configured', () => {
+    vi.mocked(HttpService.makeCallToBackend).mockImplementation((opts: any) => {
+      if (opts.path === '/m8flow/notification-smtp-status') {
+        opts.successCallback({
+          configured: true,
+          required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+          optional_keys: ['NATS_SMTP_PORT'],
+          keys_present: {
+            NATS_SMTP_HOST: true,
+            NATS_SMTP_FROM_EMAIL: true,
+          },
+        });
+      } else {
+        opts.successCallback({
+          results: [{ id: 1, key: 'api-key', username: 'editor' }],
+          pagination: { total: 1, pages: 1 },
+        });
+      }
+    });
+
+    renderList();
+    expect(screen.queryByTestId('smtp-notification-warning')).toBeNull();
+  });
+
+  it('gracefully handles failure to fetch SMTP status', () => {
+    vi.mocked(HttpService.makeCallToBackend).mockImplementation((opts: any) => {
+      if (opts.path === '/m8flow/notification-smtp-status') {
+        opts.failureCallback?.();
+      } else {
+        opts.successCallback({
+          results: [{ id: 1, key: 'api-key', username: 'editor' }],
+          pagination: { total: 1, pages: 1 },
+        });
+      }
+    });
+
+    renderList();
+    expect(screen.queryByTestId('smtp-notification-warning')).toBeNull();
+    expect(screen.getByText('api-key')).toBeInTheDocument();
+  });
 });

--- a/m8flow-frontend/src/views/SecretList.tsx
+++ b/m8flow-frontend/src/views/SecretList.tsx
@@ -148,14 +148,14 @@ export default function SecretList() {
   const { page, perPage } = getPageInfoFromSearchParams(searchParams);
 
   const missingSmtpKeys =
-    smtpStatus && !smtpStatus.configured
+    smtpStatus && !smtpStatus.configured && smtpStatus.keys_present
       ? Object.entries(smtpStatus.keys_present)
           .filter(([, present]) => !present)
           .map(([key]) => key)
       : [];
 
-  const smtpBanner = !smtpLoading && smtpStatus ? (
-    smtpStatus.configured ? null : (
+  const smtpBanner =
+    !smtpLoading && smtpStatus && smtpStatus.configured === false ? (
       <Alert
         severity="warning"
         sx={{ mb: 2 }}
@@ -163,11 +163,13 @@ export default function SecretList() {
       >
         <AlertTitle>{t('smtp_notification_warning_title')}</AlertTitle>
         {t('smtp_notification_warning_body', {
-          keys: missingSmtpKeys.join(', '),
+          keys:
+            missingSmtpKeys.length > 0
+              ? missingSmtpKeys.join(', ')
+              : 'NATS_SMTP_HOST, NATS_SMTP_FROM_EMAIL',
         })}
       </Alert>
-    )
-  ) : null;
+    ) : null;
 
   const table = (
     <TableContainer component={Paper}>

--- a/m8flow-frontend/src/views/SecretList.tsx
+++ b/m8flow-frontend/src/views/SecretList.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import {
+  Alert,
+  AlertTitle,
   Box,
   Button,
   Dialog,
@@ -41,6 +43,13 @@ type SecretRow = {
   tenantId?: string;
 };
 
+interface SmtpStatus {
+  configured: boolean;
+  required_keys: string[];
+  optional_keys: string[];
+  keys_present: Record<string, boolean>;
+}
+
 function secretsListPath(page: number, perPage: number, tenantId?: string | null) {
   const qs = new URLSearchParams({
     per_page: String(perPage),
@@ -66,6 +75,8 @@ export default function SecretList() {
   const [rows, setRows] = useState<SecretRow[]>([]);
   const [pageMeta, setPageMeta] = useState<any>(null);
   const [pendingDelete, setPendingDelete] = useState<SecretRow | null>(null);
+  const [smtpStatus, setSmtpStatus] = useState<SmtpStatus | null>(null);
+  const [smtpLoading, setSmtpLoading] = useState(true);
 
   const { ability, permissionsLoaded } = usePermissionFetcher({
     [targetUris.authenticationListPath]: ['GET'],
@@ -105,6 +116,23 @@ export default function SecretList() {
     load,
   ]);
 
+  // Check notification SMTP configuration status
+  useEffect(() => {
+    if (!permissionsLoaded) return;
+    setSmtpLoading(true);
+    HttpService.makeCallToBackend({
+      path: '/m8flow/notification-smtp-status',
+      successCallback: (result: SmtpStatus) => {
+        setSmtpStatus(result);
+        setSmtpLoading(false);
+      },
+      failureCallback: () => {
+        // Endpoint may not be available (permissions, older backend); silently skip.
+        setSmtpLoading(false);
+      },
+    });
+  }, [permissionsLoaded, selectedTenantId]);
+
   const confirmDelete = (key: string) => {
     HttpService.makeCallToBackend({
       path: `/secrets/${key}`,
@@ -118,6 +146,28 @@ export default function SecretList() {
   }
 
   const { page, perPage } = getPageInfoFromSearchParams(searchParams);
+
+  const missingSmtpKeys =
+    smtpStatus && !smtpStatus.configured
+      ? Object.entries(smtpStatus.keys_present)
+          .filter(([, present]) => !present)
+          .map(([key]) => key)
+      : [];
+
+  const smtpBanner = !smtpLoading && smtpStatus ? (
+    smtpStatus.configured ? null : (
+      <Alert
+        severity="warning"
+        sx={{ mb: 2 }}
+        data-testid="smtp-notification-warning"
+      >
+        <AlertTitle>{t('smtp_notification_warning_title')}</AlertTitle>
+        {t('smtp_notification_warning_body', {
+          keys: missingSmtpKeys.join(', '),
+        })}
+      </Alert>
+    )
+  ) : null;
 
   const table = (
     <TableContainer component={Paper}>
@@ -181,6 +231,8 @@ export default function SecretList() {
           </Button>
         </Can>
       </Box>
+
+      {smtpBanner}
 
       {rows.length > 0 ? (
         <PaginationForTable


### PR DESCRIPTION
## JIRA Ticket
<img width="1890" height="947" alt="image" src="https://github.com/user-attachments/assets/fd18253a-fc67-435e-a139-779a3fcb1613" />
<img width="1911" height="950" alt="image" src="https://github.com/user-attachments/assets/2d47fdc0-e88a-4d2c-ba1f-4b61ba9e8662" />

https://aottech.atlassian.net/browse/M8F-434
## Description
We resolved the issue where external form email notifications fail silently when required `NATS_SMTP_*` secrets are missing for a tenant:

1. **Terminal Notification State to Stop Infinite Retries**:
   - Added `smtp_not_configured` to `ExternalFormRequestStatus` in [`external_form_request.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/models/external_form_request.py).
   - In [`external_form_notification_service.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py), when SMTP settings are missing, `notify()` transitions the tracking row atomically to `smtp_not_configured`, logs an explicit `ERROR` with tenant details and missing required secrets (`NATS_SMTP_HOST`, `NATS_SMTP_FROM_EMAIL`), and returns `"failed:smtp_not_configured"`.
   - The worker sweep excludes `smtp_not_configured` requests, stopping infinite retry loops.

2. **Tenant SMTP Status Endpoint**:
   - Added `check_smtp_configured()` class method to [`ExternalFormNotificationService`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py#L227-L246) returning presence flags for required (`NATS_SMTP_HOST`, `NATS_SMTP_FROM_EMAIL`) and optional SMTP secrets without exposing sensitive secret values.
   - Added `GET /m8flow/notification-smtp-status` endpoint in [`notification_smtp_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/routes/notification_smtp_controller.py) and documented it in [`api.yml`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/api.yml).

3. **Dynamic SMTP Status Warning in BPMN Modeler Properties Panel**:
   - Updated [`ExternalFormPropertiesProvider.js`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js) to query `/m8flow/notification-smtp-status`.
   - When SMTP is not configured, the field description in the Modeler shows:
     > `⚠️ Warning: Notification SMTP is not configured for this tenant (missing: NATS_SMTP_HOST, NATS_SMTP_FROM_EMAIL). Assignees will not receive emails until configured in Configuration > Secrets or Connectors.`
   - When configured, it shows:
     > `✓ Notification SMTP is configured.`

4. **Discoverable SMTP Configuration on Connectors Page**:
   - Registered `nats_smtp` in `CONNECTOR_METADATA` within [`connectors_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/routes/connectors_controller.py) so administrators can configure Notification Email SMTP settings through **Connectors > Configure**.

5. **UI Warning Banner on Secrets Page**:
   - Updated [`SecretList.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/views/SecretList.tsx) to query `/m8flow/notification-smtp-status`.
   - When required secrets are missing, an `Alert` banner is displayed listing the specific missing keys and warning that notification emails will not be sent until configured.
   - Added translation keys in [`en_us/translation.json`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/locales/en_us/translation.json) and registered `notificationSmtpStatusPath` in [`M8flowUriListForPermissions.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx).

---

## Test Suites Added & Updated

### Backend Tests
1. [`test_external_form_notification_service.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py):
   - `test_unconfigured_smtp_marks_smtp_not_configured`: Asserts unconfigured tenant SMTP transitions row to `ExternalFormRequestStatus.smtp_not_configured` and returns `"failed:smtp_not_configured"`.
   - `test_missing_from_email_is_smtp_not_configured`: Asserts missing `NATS_SMTP_FROM_EMAIL` moves request to `smtp_not_configured`.
   - `TestSmtpNotConfiguredSweep.test_smtp_not_configured_not_swept`: Asserts requests with `smtp_not_configured` are ignored by `sweep_candidates`.
   - `TestCheckSmtpConfigured`: Verifies `check_smtp_configured()` returns proper boolean flags for present/missing required and optional keys.

2. [`test_notification_smtp_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/routes/test_notification_smtp_controller.py):
   - `test_returns_status_with_200`: Verifies `GET /notification-smtp-status` returns HTTP 200 with the SMTP status dictionary.
   - `test_handles_api_error_gracefully`: Verifies error handling through `handle_api_errors`.

3. [`test_connectors_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/routes/test_connectors_controller.py):
   - `test_connectors_grouped_injects_nats_smtp_virtual_connector`: Verifies `nats_smtp` connector card is returned in `/m8flow/connectors-grouped` with all `NATS_SMTP_*` configuration fields.

### Frontend Tests
1. [`SecretList.test.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/views/SecretList.test.tsx):
   - `renders SMTP warning banner when notification SMTP is unconfigured`: Verifies warning alert with missing keys is rendered.
   - `does not render SMTP warning banner when notification SMTP is configured`: Verifies warning alert is absent when configured.
   - `gracefully handles failure to fetch SMTP status`: Verifies fallback handling when the endpoint is unreachable.

2. [`ExternalFormPropertiesProvider.test.ts`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts):
   - `adds a single "Web Form (External Form)" URL group to user tasks`: Verifies description includes `NATS_SMTP_HOST` and `NATS_SMTP_FROM_EMAIL`.
   - `displays warning when SMTP status is unconfigured`: Verifies dynamic warning is shown in Modeler when SMTP status is unconfigured.
   - `displays configured indicator when SMTP is configured`: Verifies positive confirmation in Modeler when SMTP status is configured.

---

## Changed Files

| File | Description |
|---|---|
| [`m8flow-backend/src/m8flow_backend/models/external_form_request.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/models/external_form_request.py) | Added `smtp_not_configured` enum value |
| [`m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py) | Terminal status transition on missing SMTP, error logging, and `check_smtp_configured()` |
| [`m8flow-backend/src/m8flow_backend/routes/notification_smtp_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/routes/notification_smtp_controller.py) | Controller for `GET /notification-smtp-status` |
| [`m8flow-backend/src/m8flow_backend/routes/connectors_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/routes/connectors_controller.py) | Added `nats_smtp` connector metadata and injection into grouped connectors |
| [`m8flow-backend/src/m8flow_backend/api.yml`](file:///d:/m8f-new/m8flow/m8flow-backend/src/m8flow_backend/api.yml) | OpenAPI spec for `/notification-smtp-status` |
| [`m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py) | Unit tests for unconfigured SMTP handling and status checks |
| [`m8flow-backend/tests/unit/m8flow_backend/routes/test_notification_smtp_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/routes/test_notification_smtp_controller.py) | Route tests for SMTP status controller |
| [`m8flow-backend/tests/unit/m8flow_backend/routes/test_connectors_controller.py`](file:///d:/m8f-new/m8flow/m8flow-backend/tests/unit/m8flow_backend/routes/test_connectors_controller.py) | Test for `nats_smtp` connector injection |
| [`m8flow-frontend/src/views/SecretList.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/views/SecretList.tsx) | Warning banner for missing SMTP secrets |
| [`m8flow-frontend/src/views/SecretList.test.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/views/SecretList.test.tsx) | Unit tests for SecretList warning banner |
| [`m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js) | Modeler properties panel external form description with live SMTP status warning/indicator |
| [`m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts) | Modeler provider unit tests covering unconfigured vs configured states |
| [`m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx) | Added `notificationSmtpStatusPath` URI |
| [`m8flow-frontend/src/locales/en_us/translation.json`](file:///d:/m8f-new/m8flow/m8flow-frontend/src/locales/en_us/translation.json) | Translation keys for SMTP warnings |



## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

<!-- How was this tested? -->


## Related Issues

Closes #

