### PR TITLE
fixed smtp notification

### DIFF
--- a/m8flow-backend/migrations/versions/r1k2l3m4n5o6_add_external_form_request_last_error.py
+++ b/m8flow-backend/migrations/versions/r1k2l3m4n5o6_add_external_form_request_last_error.py
@@ -31,26 +31,53 @@ COLUMN_NAME = "last_error"
 COLUMN_LENGTH = 500
 
 
-def _table_exists() -> bool:
-    return TABLE_NAME in sa.inspect(op.get_bind()).get_table_names()
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
 
 
-def _column_exists() -> bool:
-    # Callers must check _table_exists() first: "no such column" and "no such table" are
-    # both false here, and only the former is safe to ALTER.
-    if not _table_exists():
+def _schema() -> str | None:
+    try:
+        return getattr(op.get_context(), "version_table_schema", None)
+    except Exception:
+        return None
+
+
+def _table_exists(inspector: sa.Inspector | None = None, schema: str | None | object = ...) -> bool:
+    insp = inspector if inspector is not None else _inspector()
+    sch = _schema() if schema is ... else schema  # type: ignore[assignment]
+    if insp.has_table(TABLE_NAME, schema=sch):
+        return True
+    return TABLE_NAME in insp.get_table_names(schema=sch)
+
+
+def _column_exists(inspector: sa.Inspector | None = None, schema: str | None | object = ...) -> bool:
+    insp = inspector if inspector is not None else _inspector()
+    sch = _schema() if schema is ... else schema  # type: ignore[assignment]
+    if not _table_exists(inspector=insp, schema=sch):
         return False
-    return any(column["name"] == COLUMN_NAME for column in sa.inspect(op.get_bind()).get_columns(TABLE_NAME))
+    try:
+        columns = insp.get_columns(TABLE_NAME, schema=sch)
+        return any(column["name"] == COLUMN_NAME for column in columns)
+    except Exception:
+        return False
 
 
 def upgrade():
     # Additive and nullable: existing rows keep their data and read back as NULL.
-    if _table_exists() and not _column_exists():
-        op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.String(length=COLUMN_LENGTH), nullable=True))
+    insp = _inspector()
+    schema = _schema()
+    if _table_exists(inspector=insp, schema=schema) and not _column_exists(inspector=insp, schema=schema):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(COLUMN_NAME, sa.String(length=COLUMN_LENGTH), nullable=True),
+            schema=schema,
+        )
 
 
 def downgrade():
     # Drops diagnostic text only; no request state lives in this column.
-    if _column_exists():
-        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+    insp = _inspector()
+    schema = _schema()
+    if _column_exists(inspector=insp, schema=schema):
+        with op.batch_alter_table(TABLE_NAME, schema=schema) as batch_op:
             batch_op.drop_column(COLUMN_NAME)

--- a/m8flow-backend/migrations/versions/r1k2l3m4n5o6_add_external_form_request_last_error.py
+++ b/m8flow-backend/migrations/versions/r1k2l3m4n5o6_add_external_form_request_last_error.py
@@ -1,0 +1,56 @@
+"""Add last_error to m8flow_external_form_requests
+
+Reverses the "no last_error column" decision recorded in k3c4d5e6f7a9. That note assumed
+failure reasons only ever needed to reach an operator reading worker logs. They also need
+to reach a tenant admin in the UI: a request parked in the new ``smtp_unconfigured`` status
+is useless to diagnose without knowing which NATS_SMTP_* secrets were missing, and a
+generic SMTP rejection is equally opaque.
+
+The column is bounded (500 chars, truncated on write) and only ever receives text that is
+already being logged — never a secret value.
+
+Revision ID: r1k2l3m4n5o6
+Revises: q0j1k2l3m4n5
+Create Date: 2026-08-19
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "r1k2l3m4n5o6"
+down_revision = "q0j1k2l3m4n5"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "m8flow_external_form_requests"
+COLUMN_NAME = "last_error"
+COLUMN_LENGTH = 500
+
+
+def _table_exists() -> bool:
+    return TABLE_NAME in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _column_exists() -> bool:
+    # Callers must check _table_exists() first: "no such column" and "no such table" are
+    # both false here, and only the former is safe to ALTER.
+    if not _table_exists():
+        return False
+    return any(column["name"] == COLUMN_NAME for column in sa.inspect(op.get_bind()).get_columns(TABLE_NAME))
+
+
+def upgrade():
+    # Additive and nullable: existing rows keep their data and read back as NULL.
+    if _table_exists() and not _column_exists():
+        op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.String(length=COLUMN_LENGTH), nullable=True))
+
+
+def downgrade():
+    # Drops diagnostic text only; no request state lives in this column.
+    if _column_exists():
+        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+            batch_op.drop_column(COLUMN_NAME)

--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -3883,7 +3883,7 @@ components:
           type: array
           items:
             type: string
-          description: Required keys that are absent, blank, or undecryptable.
+          description: Required keys that are absent.
         unreadable_keys:
           type: array
           items:

--- a/m8flow-backend/src/m8flow_backend/api.yml
+++ b/m8flow-backend/src/m8flow_backend/api.yml
@@ -2667,6 +2667,137 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /external-form-notifications/smtp-status:
+    get:
+      summary: External form email (SMTP) configuration status for the active tenant
+      description: >
+        Reports whether this tenant's NATS_SMTP_* secrets are usable, and which required
+        keys are missing or unreadable. Returns secret key *names* and flags only — never
+        a secret value. A super admin must pass tenantId, since the answer is per-tenant.
+      operationId: m8flow_backend.routes.external_form_notifications_controller.external_form_smtp_status
+      tags:
+        - ExternalFormNotifications
+      parameters:
+        - name: tenantId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Tenant to inspect. Required for super admins, ignored otherwise.
+      responses:
+        "200":
+          description: SMTP configuration status for the tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFormSmtpStatusResponse"
+        "400":
+          description: A super admin did not name a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /external-form-notifications:
+    get:
+      summary: List external form notification tracking rows for the active tenant
+      description: >
+        Paginated notification rows, newest first, so an admin can see whether each
+        notification was delivered, failed, or is parked for missing SMTP configuration.
+        The emailed reference ID is deliberately omitted — it is the recipient's
+        credential.
+      operationId: m8flow_backend.routes.external_form_notifications_controller.external_form_notification_list
+      tags:
+        - ExternalFormNotifications
+      parameters:
+        - name: process_instance_id
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Restrict to notifications for one process instance.
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Restrict to one notification status, e.g. smtp_unconfigured.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+          description: Capped at 200 by the server.
+        - name: tenantId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Tenant to inspect. Honoured for super admins, ignored otherwise.
+      responses:
+        "200":
+          description: A page of notification tracking rows.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFormNotificationListResponse"
+
+  /external-form-notifications/{request_id}/resend:
+    post:
+      summary: Requeue one external form notification for delivery
+      description: >
+        Puts a notification back at the front of the retry queue. Applies to requests
+        parked for missing SMTP configuration and to sends that failed and were released
+        for retry. The worker delivers it on its next sweep, so this is not instantaneous.
+      operationId: m8flow_backend.routes.external_form_notifications_controller.external_form_notification_resend
+      tags:
+        - ExternalFormNotifications
+      parameters:
+        - name: request_id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: The notification tracking row id.
+        - name: tenantId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Tenant that owns the row. Required for super admins.
+      responses:
+        "200":
+          description: The notification was requeued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFormNotificationResendResponse"
+        "400":
+          description: A super admin did not name a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No notification exists with that id for this tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: The notification is in a status that cannot be resent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /connectors-grouped:
     get:
       operationId: m8flow_backend.routes.connectors_controller.connectors_grouped
@@ -3730,6 +3861,116 @@ components:
               type: string
             process_instance_id:
               type: integer
+
+    ExternalFormSmtpStatusResponse:
+      type: object
+      description: >
+        Secret key names and configuration flags only. Never contains a secret value.
+      properties:
+        configured:
+          type: boolean
+          description: True when every required key resolves to a usable value.
+        required_keys:
+          type: array
+          items:
+            type: string
+          description: Keys without which no external form email can be sent.
+        optional_keys:
+          type: array
+          items:
+            type: string
+        missing_required_keys:
+          type: array
+          items:
+            type: string
+          description: Required keys that are absent, blank, or undecryptable.
+        unreadable_keys:
+          type: array
+          items:
+            type: string
+          description: >
+            Keys whose secret exists but does not resolve (blank, or the backend
+            encryption key changed). Re-entering the key is not the fix for these.
+        reason:
+          type: string
+          nullable: true
+          description: Why sending is blocked; null when configured.
+        configured_keys:
+          type: array
+          items:
+            type: string
+          description: Keys that resolve to a usable value. Names only.
+
+    ExternalFormNotification:
+      type: object
+      description: >
+        One notification tracking row. The emailed reference ID is deliberately absent —
+        it is the recipient's bearer credential.
+      properties:
+        id:
+          type: integer
+        process_instance_id:
+          type: integer
+        task_guid:
+          type: string
+        email:
+          type: string
+        status:
+          type: string
+          description: >
+            pending, notified, submitted, completed, failed, expired, superseded, or
+            smtp_unconfigured (parked: the tenant has no usable SMTP configuration).
+        attempts:
+          type: integer
+        last_error:
+          type: string
+          nullable: true
+        created_at_in_seconds:
+          type: integer
+        updated_at_in_seconds:
+          type: integer
+        notified_at_in_seconds:
+          type: integer
+          nullable: true
+        expires_at_in_seconds:
+          type: integer
+          nullable: true
+        tenantId:
+          type: string
+          description: Present for super-admin requests only.
+        tenantName:
+          type: string
+          nullable: true
+          description: Present for super-admin requests only.
+
+    ExternalFormNotificationListResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExternalFormNotification"
+        pagination:
+          type: object
+          properties:
+            count:
+              type: integer
+            total:
+              type: integer
+            pages:
+              type: integer
+
+    ExternalFormNotificationResendResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        id:
+          type: integer
+        status:
+          type: string
+        message:
+          type: string
 
     M8flowTriggerRequest:
       type: object

--- a/m8flow-backend/src/m8flow_backend/config/permissions/m8flow.yml
+++ b/m8flow-backend/src/m8flow_backend/config/permissions/m8flow.yml
@@ -232,6 +232,24 @@ permissions:
     groups: ["tenant-admin", "editor", "integrator", "super-admin"]
     actions: [read]
     uri: /m8flow/connectors-grouped
+  # Editors need this one to see the missing-SMTP warning in the BPMN modeler's External
+  # Form group. It returns secret key names and configuration flags only, never values.
+  read-external-form-smtp-status:
+    groups: ["tenant-admin", "editor", "super-admin"]
+    actions: [read]
+    uri: /m8flow/external-form-notifications/smtp-status
+  read-external-form-notifications:
+    groups: ["tenant-admin", "super-admin"]
+    actions: [read]
+    uri: /m8flow/external-form-notifications
+  read-external-form-notification-items:
+    groups: ["tenant-admin", "super-admin"]
+    actions: [read]
+    uri: /m8flow/external-form-notifications/*
+  resend-external-form-notifications:
+    groups: ["tenant-admin", "super-admin"]
+    actions: [create]
+    uri: /m8flow/external-form-notifications/*
   read-mcp-connection-page:
     groups: ["everybody"]
     actions: [read]

--- a/m8flow-backend/src/m8flow_backend/models/external_form_request.py
+++ b/m8flow-backend/src/m8flow_backend/models/external_form_request.py
@@ -20,15 +20,40 @@ class ExternalFormRequestStatus(SpiffEnum):
     failed = "failed"
     expired = "expired"
     superseded = "superseded"
+    # Terminal-until-reconfigured: the tenant has no usable NATS_SMTP_* secrets, so no
+    # amount of retrying can deliver the email. Deliberately absent from
+    # ExternalFormNotificationService.CLAIMABLE_STATUSES — that tuple is the only
+    # predicate the sweep uses, so parking a row here stops the retry loop dead — and
+    # from ACTIONABLE_STATUSES, since the link was never delivered to anyone.
+    # Rows leave this state via revive_smtp_unconfigured() (auto, once the tenant's
+    # SMTP secrets appear) or an admin resend.
+    smtp_unconfigured = "smtp_unconfigured"
 
 
 # Statuses for which the secure link may still be used to submit the form.
-# "failed" means a notification/resume attempt failed; the link itself stays usable.
+# "failed" means a notification/resume attempt failed; the link itself stays usable,
+# because it was already delivered at least once.
+#
+# "smtp_unconfigured" is deliberately absent. Such a request was never emailed, so nobody
+# can legitimately hold its link — the only way to obtain one is to read reference_id out
+# of the database. Accepting it would let an operator submit a form as the recipient. Once
+# SMTP is configured, revive_smtp_unconfigured() returns the row to "pending" and the link
+# becomes usable in the normal way.
 ACTIONABLE_STATUSES = (
     ExternalFormRequestStatus.pending.value,
     ExternalFormRequestStatus.notified.value,
     ExternalFormRequestStatus.failed.value,
 )
+
+# Statuses in which the request is still open — not submitted, completed, superseded, or
+# expired. Broader than ACTIONABLE_STATUSES: a parked request is not submittable, but it is
+# still the live request for its (task, recipient) pair, so it must suppress duplicate row
+# creation, still be expired by TTL, and still be superseded when a sibling submits.
+OPEN_STATUSES = ACTIONABLE_STATUSES + (ExternalFormRequestStatus.smtp_unconfigured.value,)
+
+# Column width of last_error. Writers must truncate to this; an SMTP exception message
+# (or a provider's multi-line rejection) can easily exceed it.
+LAST_ERROR_MAX_LENGTH = 500
 
 
 @dataclass
@@ -61,6 +86,9 @@ class ExternalFormRequestModel(M8fTenantScopedMixin, TenantScoped, Spiffworkflow
     expires_at_in_seconds: Optional[int] = db.Column(db.Integer, nullable=True)
     attempts: int = db.Column(db.Integer, nullable=False, default=0)
     notified_at_in_seconds: Optional[int] = db.Column(db.Integer, nullable=True)
+    # Why the last delivery attempt failed, so an admin can diagnose from the UI instead
+    # of the worker logs. Bounded and truncated on write; never holds secret values.
+    last_error: Optional[str] = db.Column(db.String(LAST_ERROR_MAX_LENGTH), nullable=True)
 
     def is_actionable(self) -> bool:
         return self.status in ACTIONABLE_STATUSES
@@ -72,6 +100,26 @@ class ExternalFormRequestModel(M8fTenantScopedMixin, TenantScoped, Spiffworkflow
             "status": self.status,
             "external_form_url": self.external_form_url,
             "process_instance_id": self.process_instance_id,
+        }
+
+    def to_admin_dict(self) -> dict[str, Any]:
+        """Shape returned to tenant admins in the notification-status list.
+
+        Deliberately omits reference_id: it is the bearer credential in the emailed
+        secure link (external_form_show/submit authenticate on it alone), so it must not
+        be readable by anyone other than its recipient. Admin actions key on `id`."""
+        return {
+            "id": self.id,
+            "process_instance_id": self.process_instance_id,
+            "task_guid": self.task_guid,
+            "email": self.email,
+            "status": self.status,
+            "attempts": self.attempts,
+            "last_error": self.last_error,
+            "created_at_in_seconds": self.created_at_in_seconds,
+            "updated_at_in_seconds": self.updated_at_in_seconds,
+            "notified_at_in_seconds": self.notified_at_in_seconds,
+            "expires_at_in_seconds": self.expires_at_in_seconds,
         }
 
     def __repr__(self) -> str:

--- a/m8flow-backend/src/m8flow_backend/routes/external_form_notifications_controller.py
+++ b/m8flow-backend/src/m8flow_backend/routes/external_form_notifications_controller.py
@@ -1,0 +1,175 @@
+"""Admin-facing view of external-form email notifications.
+
+Gives tenant admins the two things the delivery path could previously only report to the
+worker log: whether this tenant's SMTP secrets are usable at all, and what happened to each
+individual notification. Also lets them requeue a request once the configuration is fixed.
+
+Tenant scoping: for ordinary requests the tenant-scoping query listener
+(services/tenant_scoping_patch) filters every SELECT, and nothing here may bypass it.
+Super-admin requests are *exempt* from that listener, so each handler resolves an explicit
+tenant filter from ?tenantId= and applies it itself — the same compensation
+secrets_controller_patch and process_models_controller_patch already make.
+"""
+
+from __future__ import annotations
+
+import flask.wrappers
+from flask import jsonify, make_response
+from flask import request as flask_request
+
+from m8flow_backend.helpers.response_helper import error_response, handle_api_errors, success_response
+from m8flow_backend.models.external_form_request import ExternalFormRequestModel
+from m8flow_backend.models.external_form_request import ExternalFormRequestStatus
+from m8flow_backend.services.external_form_notification_service import ExternalFormNotificationService
+from m8flow_backend.tenancy import is_super_admin_request
+
+# Guards against a caller asking for an unbounded page.
+MAX_PER_PAGE = 200
+
+
+def _requested_tenant_id() -> str | None:
+    value = flask_request.args.get("tenantId") or flask_request.args.get("tenant_id")
+    if isinstance(value, str):
+        return value.strip() or None
+    return None
+
+
+def _explicit_tenant_filter() -> str | None:
+    """Tenant to filter on, or None to rely on the ambient tenant-scoping listener.
+
+    Only super-admin requests get an explicit filter: they are the ones the listener
+    exempts. Honouring ?tenantId= for a normal user would let them name another tenant,
+    but the listener still scopes them, so the extra filter could only ever narrow their
+    own tenant to nothing — never widen it."""
+    if not is_super_admin_request():
+        return None
+    return _requested_tenant_id()
+
+
+def _tenant_name_map(tenant_ids: set[str]) -> dict[str, str]:
+    if not tenant_ids:
+        return {}
+    from m8flow_backend.models.m8flow_tenant import M8flowTenantModel
+
+    tenants = M8flowTenantModel.query.filter(M8flowTenantModel.id.in_(tenant_ids)).all()
+    return {tenant.id: tenant.name for tenant in tenants}
+
+
+@handle_api_errors
+def external_form_smtp_status() -> flask.wrappers.Response:
+    """Whether the tenant can send external-form emails, and which NATS_SMTP_* secrets it
+    still needs. Returns key names and flags only — never a value.
+
+    A super admin must name the tenant: without one, the query would span every tenant and
+    could report "configured" because some *other* tenant has SMTP set up."""
+    tenant_id = _explicit_tenant_filter()
+    if is_super_admin_request() and tenant_id is None:
+        return error_response(
+            "tenant_id_required",
+            "Select a tenant to see its external form email configuration.",
+            400,
+        )
+    status = ExternalFormNotificationService.smtp_configuration_status(tenant_id)
+    return make_response(jsonify(status), 200)
+
+
+@handle_api_errors
+def external_form_notification_list(
+    process_instance_id: int | None = None,
+    status: str | None = None,
+    page: int = 1,
+    per_page: int = 50,
+) -> flask.wrappers.Response:
+    """Paginated notification tracking rows for the active tenant, newest first.
+
+    Rows are serialized with to_admin_dict(), which deliberately omits reference_id: that
+    token is the credential in the recipient's emailed link. Recipient email addresses are
+    included, so a super admin querying across tenants gets each row labelled with its
+    owning tenant rather than an unattributed mix."""
+    per_page = max(1, min(int(per_page), MAX_PER_PAGE))
+    tenant_id = _explicit_tenant_filter()
+
+    query = ExternalFormRequestModel.query
+    if tenant_id is not None:
+        query = query.filter(ExternalFormRequestModel.m8f_tenant_id == tenant_id)
+    if process_instance_id is not None:
+        query = query.filter(ExternalFormRequestModel.process_instance_id == process_instance_id)
+    if status:
+        query = query.filter(ExternalFormRequestModel.status == status)
+
+    results = query.order_by(ExternalFormRequestModel.created_at_in_seconds.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+
+    rows = [row.to_admin_dict() for row in results.items]
+    if is_super_admin_request():
+        tenant_ids = {row.m8f_tenant_id for row in results.items if row.m8f_tenant_id}
+        name_by_id = _tenant_name_map(tenant_ids)
+        for payload, row in zip(rows, results.items):
+            payload["tenantId"] = row.m8f_tenant_id
+            payload["tenantName"] = name_by_id.get(row.m8f_tenant_id)
+
+    return make_response(
+        jsonify(
+            {
+                "results": rows,
+                "pagination": {
+                    "count": len(results.items),
+                    "total": results.total,
+                    "pages": results.pages,
+                },
+            }
+        ),
+        200,
+    )
+
+
+@handle_api_errors
+def external_form_notification_resend(request_id: int) -> flask.wrappers.Response:
+    """Requeue one notification for delivery.
+
+    Applies to requests parked as smtp_unconfigured and to sends that failed and were
+    released for retry. The notification worker's sweep picks the row up on its next pass
+    (M8FLOW_NOTIFICATION_SWEEP_INTERVAL_SECONDS), so delivery is not instantaneous.
+
+    A super admin must name the tenant: request_id is a bare integer, so without a filter
+    it would address any tenant's row."""
+    tenant_id = _explicit_tenant_filter()
+    if is_super_admin_request() and tenant_id is None:
+        return error_response(
+            "tenant_id_required",
+            "Select a tenant before resending one of its notifications.",
+            400,
+        )
+
+    query = ExternalFormRequestModel.query.filter(ExternalFormRequestModel.id == request_id)
+    if tenant_id is not None:
+        query = query.filter(ExternalFormRequestModel.m8f_tenant_id == tenant_id)
+    row = query.first()
+    if row is None:
+        return error_response(
+            "external_form_request_not_found",
+            "No external form notification exists with that id for this tenant.",
+            404,
+        )
+
+    if not ExternalFormNotificationService.requeue(request_id, tenant_id=tenant_id):
+        return error_response(
+            "external_form_request_not_resendable",
+            (
+                f"A notification in status '{row.status}' cannot be resent. Only requests"
+                " awaiting delivery, parked for missing SMTP configuration, or whose send"
+                " failed can be requeued."
+            ),
+            409,
+        )
+
+    return success_response(
+        {
+            "ok": True,
+            "id": request_id,
+            "status": ExternalFormRequestStatus.pending.value,
+            "message": "Notification requeued; the worker will retry it on its next sweep.",
+        },
+        200,
+    )

--- a/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
@@ -301,7 +301,7 @@ class ExternalFormNotificationService:
             "configured": readiness["ok"],
             "required_keys": list(REQUIRED_SMTP_SECRET_KEYS),
             "optional_keys": list(OPTIONAL_SMTP_SECRET_KEYS),
-            "missing_required_keys": readiness["unusable"],
+            "missing_required_keys": readiness["missing"],
             "unreadable_keys": readiness["unreadable"],
             "reason": readiness["reason"],
             "configured_keys": configured_keys,

--- a/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py
@@ -20,6 +20,7 @@ from spiffworkflow_backend.models.db import db
 
 from m8flow_backend.config import notification_max_attempts
 from m8flow_backend.config import notification_sweep_grace_seconds
+from m8flow_backend.models.external_form_request import LAST_ERROR_MAX_LENGTH
 from m8flow_backend.models.external_form_request import ExternalFormRequestModel
 from m8flow_backend.models.external_form_request import ExternalFormRequestStatus
 
@@ -49,12 +50,27 @@ SMTP_SECRET_KEYS = {
     "ssl": "NATS_SMTP_SSL",
 }
 
+# The minimum needed to send at all; resolve_smtp_settings() returns None without both.
+# This must stay exactly the pair that function requires, or the status API would report
+# "configured" for a tenant that still cannot send.
+REQUIRED_SMTP_SECRET_KEYS = (SMTP_SECRET_KEYS["host"], SMTP_SECRET_KEYS["from_email"])
+OPTIONAL_SMTP_SECRET_KEYS = tuple(key for key in SMTP_SECRET_KEYS.values() if key not in REQUIRED_SMTP_SECRET_KEYS)
+
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
 def _is_truthy(value: str | None) -> bool:
     """Lenient boolean for tenant-set SMTP flags (true/1/yes/on, case-insensitive)."""
     return (value or "").strip().lower() in _TRUTHY
+
+
+def _truncate_error(message: Any) -> str | None:
+    """Fit a failure reason into last_error. SMTP rejections are routinely longer than
+    the column, and an oversized value would fail the write on strict backends."""
+    text = str(message or "").strip()
+    if not text:
+        return None
+    return text[:LAST_ERROR_MAX_LENGTH]
 
 
 class ExternalFormNotificationService:
@@ -82,6 +98,8 @@ class ExternalFormNotificationService:
                 notified_at_in_seconds=now,
                 attempts=ExternalFormRequestModel.attempts + 1,
                 updated_at_in_seconds=now,
+                # Clear any prior diagnosis; it describes an attempt that is now superseded.
+                last_error=None,
             )
             .execution_options(synchronize_session=False)
         )
@@ -103,6 +121,7 @@ class ExternalFormNotificationService:
                 status=ExternalFormRequestStatus.failed.value,
                 notified_at_in_seconds=None,
                 updated_at_in_seconds=now,
+                last_error=_truncate_error(error_message),
             )
             .execution_options(synchronize_session=False)
         )
@@ -198,6 +217,97 @@ class ExternalFormNotificationService:
         return value or None
 
     @classmethod
+    def _read_secret_for_tenant(cls, key: str, tenant_id: str | None) -> str | None:
+        """Decrypted value of a secret, scoping to `tenant_id` explicitly when supplied.
+
+        Super-admin requests are exempt from the tenant-scoping query listener (see
+        tenant_scoping_patch._tenant_scope_queries), so the ambient scoping the plain
+        `_read_tenant_secret` relies on does not apply to them. Without an explicit filter
+        a super admin would read some other tenant's NATS_SMTP_HOST and be told the tenant
+        they are looking at is configured. Callers with no explicit tenant keep the
+        ambient-scoped path."""
+        if tenant_id is None:
+            return cls._read_tenant_secret(key)
+
+        from spiffworkflow_backend.models.secret_model import SecretModel
+        from spiffworkflow_backend.services.secret_service import SecretService
+
+        secret = SecretModel.query.filter(SecretModel.key == key, SecretModel.m8f_tenant_id == tenant_id).first()
+        if secret is None:
+            return None
+        try:
+            value = SecretService._decrypt(secret.value)
+        except Exception as exc:
+            LOGGER.warning("external-form-notify: could not decrypt a tenant secret (%s)", type(exc).__name__)
+            return None
+        value = (value or "").strip()
+        return value or None
+
+    @classmethod
+    def _present_smtp_secret_keys(cls, tenant_id: str | None = None) -> set[str]:
+        """Which NATS_SMTP_* keys the tenant has rows for. Presence only, no decryption,
+        so it stays a single query."""
+        from spiffworkflow_backend.models.secret_model import SecretModel
+
+        query = SecretModel.query.filter(SecretModel.key.in_(list(SMTP_SECRET_KEYS.values())))
+        if tenant_id is not None:
+            query = query.filter(SecretModel.m8f_tenant_id == tenant_id)
+        return {row.key for row in query.all()}
+
+    @classmethod
+    def smtp_readiness(cls, tenant_id: str | None = None) -> dict[str, Any]:
+        """Whether the tenant can send, and why not when it cannot.
+
+        Separates a key that was never set from one whose row exists but does not resolve
+        to a usable value (blank, or undecryptable because the backend encryption key
+        changed). Both block sending but need completely different fixes, so the reason an
+        admin reads must not collapse them into "missing"."""
+        missing: list[str] = []
+        unreadable: list[str] = []
+        present = cls._present_smtp_secret_keys(tenant_id)
+        for key in REQUIRED_SMTP_SECRET_KEYS:
+            if cls._read_secret_for_tenant(key, tenant_id):
+                continue
+            (unreadable if key in present else missing).append(key)
+
+        if unreadable:
+            reason = (
+                "SMTP secrets exist but could not be read (blank value, or the backend"
+                " encryption key changed): " + ", ".join(unreadable)
+            )
+        elif missing:
+            reason = "SMTP is not configured for this tenant. Missing required secrets: " + ", ".join(missing)
+        else:
+            reason = None
+        return {
+            "missing": missing,
+            "unreadable": unreadable,
+            "unusable": missing + unreadable,
+            "reason": reason,
+            "ok": reason is None,
+        }
+
+    @classmethod
+    def smtp_configuration_status(cls, tenant_id: str | None = None) -> dict[str, Any]:
+        """Whether the tenant can send external-form emails, and which secret keys it
+        still needs. Returns key *names* only — never a secret value.
+
+        ``configured_keys`` lists keys that resolve to a usable (decryptable, non-blank)
+        value, including optional ones. Presence of a row alone is not enough."""
+        readiness = cls.smtp_readiness(tenant_id)
+        present_keys = cls._present_smtp_secret_keys(tenant_id)
+        configured_keys = sorted(key for key in present_keys if cls._read_secret_for_tenant(key, tenant_id))
+        return {
+            "configured": readiness["ok"],
+            "required_keys": list(REQUIRED_SMTP_SECRET_KEYS),
+            "optional_keys": list(OPTIONAL_SMTP_SECRET_KEYS),
+            "missing_required_keys": readiness["unusable"],
+            "unreadable_keys": readiness["unreadable"],
+            "reason": readiness["reason"],
+            "configured_keys": configured_keys,
+        }
+
+    @classmethod
     def resolve_smtp_settings(cls) -> dict[str, Any] | None:
         """Per-tenant SMTP config from the recipient tenant's encrypted secrets.
 
@@ -223,6 +333,133 @@ class ExternalFormNotificationService:
             "starttls": _is_truthy(cls._read_tenant_secret(SMTP_SECRET_KEYS["starttls"])),
             "ssl": _is_truthy(cls._read_tenant_secret(SMTP_SECRET_KEYS["ssl"])),
         }
+
+    @classmethod
+    def mark_smtp_unconfigured(cls, request_ids: list[int], reason: str) -> int:
+        """Park requests that cannot be emailed because the tenant has no usable SMTP config.
+
+        'smtp_unconfigured' is outside CLAIMABLE_STATUSES, so the sweep stops considering
+        these rows entirely — this is what ends the indefinite retry loop. The status
+        guard mirrors release_failed(): a row the recipient just submitted, or one another
+        worker already claimed, is left alone."""
+        if not request_ids:
+            return 0
+        now = int(time.time())
+        result = db.session.execute(
+            sa_update(ExternalFormRequestModel)
+            .where(
+                ExternalFormRequestModel.id.in_(request_ids),
+                ExternalFormRequestModel.notified_at_in_seconds.is_(None),
+                ExternalFormRequestModel.status.in_(CLAIMABLE_STATUSES),
+            )
+            .values(
+                status=ExternalFormRequestStatus.smtp_unconfigured.value,
+                updated_at_in_seconds=now,
+                last_error=_truncate_error(reason),
+            )
+            .execution_options(synchronize_session=False)
+        )
+        db.session.commit()
+        return result.rowcount
+
+    @classmethod
+    def revive_smtp_unconfigured(
+        cls,
+        request_ids: list[int] | None = None,
+        tenant_id: str | None = None,
+    ) -> int:
+        """Return parked requests to the retry queue for one tenant.
+
+        Called automatically once the tenant's SMTP secrets appear. attempts is reset
+        because the parked attempts were never real delivery attempts — they burned no
+        SMTP connection.
+
+        UPDATEs bypass the tenant-scoping SELECT listener, so ``tenant_id`` must be passed
+        for bulk revive (no ``request_ids``). Without it this would revive parked rows
+        across every tenant. Prefer passing ``tenant_id`` for id-scoped revive too (the
+        same compensation ``requeue`` makes for super-admin / unscoped contexts)."""
+        if request_ids is None and tenant_id is None:
+            raise ValueError(
+                "revive_smtp_unconfigured requires tenant_id for bulk revive; "
+                "unscoped UPDATEs are not tenant-filtered by the SELECT listener"
+            )
+        now = int(time.time())
+        statement = (
+            sa_update(ExternalFormRequestModel)
+            .where(ExternalFormRequestModel.status == ExternalFormRequestStatus.smtp_unconfigured.value)
+            .values(
+                status=ExternalFormRequestStatus.pending.value,
+                notified_at_in_seconds=None,
+                attempts=0,
+                updated_at_in_seconds=now,
+                last_error=None,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if tenant_id is not None:
+            statement = statement.where(ExternalFormRequestModel.m8f_tenant_id == tenant_id)
+        if request_ids is not None:
+            if not request_ids:
+                return 0
+            statement = statement.where(ExternalFormRequestModel.id.in_(request_ids))
+        result = db.session.execute(statement)
+        db.session.commit()
+        return result.rowcount
+
+    # Statuses an admin may resend from: parked for missing SMTP, awaiting delivery, or
+    # failed with the claim released (notified_at cleared). A 'failed' row that still has
+    # notified_at set is a failed workflow *resume*, not a failed send — re-emailing it is
+    # wrong, which the notified_at guard in requeue() enforces.
+    RESENDABLE_STATUSES = (
+        ExternalFormRequestStatus.smtp_unconfigured.value,
+        ExternalFormRequestStatus.failed.value,
+        ExternalFormRequestStatus.pending.value,
+    )
+
+    @classmethod
+    def requeue(cls, request_id: int, tenant_id: str | None = None) -> bool:
+        """Admin resend: put one request back at the front of the retry queue.
+
+        True when the row moved. False when it is not in a resendable state (already
+        submitted/completed/superseded/expired, or a failed resume rather than a failed
+        send), which the caller reports as a conflict.
+
+        ``tenant_id`` pins the update to one tenant. Pass it whenever the caller is not
+        covered by the tenant-scoping listener — notably super-admin requests, which the
+        listener exempts, and where a bare numeric id would otherwise reach any tenant."""
+        now = int(time.time())
+        statement = (
+            sa_update(ExternalFormRequestModel)
+            .where(
+                ExternalFormRequestModel.id == request_id,
+                ExternalFormRequestModel.status.in_(cls.RESENDABLE_STATUSES),
+                ExternalFormRequestModel.notified_at_in_seconds.is_(None),
+            )
+            .values(
+                status=ExternalFormRequestStatus.pending.value,
+                attempts=0,
+                updated_at_in_seconds=now,
+                last_error=None,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if tenant_id is not None:
+            statement = statement.where(ExternalFormRequestModel.m8f_tenant_id == tenant_id)
+        result = db.session.execute(statement)
+        db.session.commit()
+        return result.rowcount == 1
+
+    @classmethod
+    def tenants_with_parked_requests(cls) -> list[str]:
+        """Tenant ids holding requests parked as smtp_unconfigured. Runs cross-tenant —
+        call without tenant context, like sweep_candidates()."""
+        rows = (
+            db.session.query(ExternalFormRequestModel.m8f_tenant_id)
+            .filter(ExternalFormRequestModel.status == ExternalFormRequestStatus.smtp_unconfigured.value)
+            .distinct()
+            .all()
+        )
+        return [row.m8f_tenant_id for row in rows]
 
     @staticmethod
     def send_email(settings: dict[str, Any], to_email: str, subject: str, text_body: str, html_body: str) -> None:
@@ -261,10 +498,21 @@ class ExternalFormNotificationService:
             return "skipped:unknown_reference"
         smtp_settings = cls.resolve_smtp_settings()
         if smtp_settings is None:
-            LOGGER.warning(
-                "external-form-notify: tenant %s has no SMTP secrets configured; leaving request id=%s pending",
+            # Retrying cannot help until an admin fixes the configuration, so park the row
+            # in a terminal status rather than leaving it pending for the sweep to re-pick
+            # forever. revive_smtp_unconfigured() brings it back once SMTP is usable.
+            readiness = cls.smtp_readiness()
+            reason = readiness["reason"] or "SMTP configuration could not be resolved for this tenant."
+            cls.mark_smtp_unconfigured([row.id], reason)
+            LOGGER.error(
+                "external-form-notify: cannot send for tenant=%s; parking request id=%s"
+                " instance=%s task=%s recipient_user_id=%s as smtp_unconfigured. %s",
                 row.m8f_tenant_id,
                 row.id,
+                row.process_instance_id,
+                row.task_guid,
+                row.recipient_user_id,
+                reason,
             )
             return "skipped:smtp_unconfigured"
         now = int(time.time())

--- a/m8flow-backend/src/m8flow_backend/services/external_form_service.py
+++ b/m8flow-backend/src/m8flow_backend/services/external_form_service.py
@@ -12,7 +12,7 @@ from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.user import UserModel
 
 from m8flow_backend.config import external_form_link_ttl_seconds
-from m8flow_backend.models.external_form_request import ACTIONABLE_STATUSES
+from m8flow_backend.models.external_form_request import OPEN_STATUSES
 from m8flow_backend.models.external_form_request import ExternalFormRequestModel
 from m8flow_backend.models.external_form_request import ExternalFormRequestStatus
 from m8flow_backend.tenancy import get_context_tenant_id, set_context_tenant_id
@@ -55,7 +55,10 @@ class ExternalFormService:
             for row in ExternalFormRequestModel.query.filter(
                 ExternalFormRequestModel.process_instance_id == process_instance_id,
                 ExternalFormRequestModel.task_guid == task_guid,
-                ExternalFormRequestModel.status.in_(ACTIONABLE_STATUSES),
+                # OPEN, not ACTIONABLE: a request parked for missing SMTP is still this
+                # recipient's live request. Issuing a second one per processor.save()
+                # would pile up rows that all get emailed once SMTP is configured.
+                ExternalFormRequestModel.status.in_(OPEN_STATUSES),
             ).all()
         }
 
@@ -115,7 +118,9 @@ class ExternalFormService:
     @classmethod
     def _expire_if_needed(cls, row: ExternalFormRequestModel) -> None:
         if (
-            row.status in ACTIONABLE_STATUSES
+            # OPEN, not ACTIONABLE: a parked request must still expire on TTL, otherwise
+            # it would sit outside every terminal check forever.
+            row.status in OPEN_STATUSES
             and row.expires_at_in_seconds is not None
             and row.expires_at_in_seconds < int(time.time())
         ):
@@ -173,6 +178,24 @@ class ExternalFormService:
                 error_code="reference_expired",
                 message="This link has expired.",
                 status_code=410,
+            )
+        if row.status == ExternalFormRequestStatus.smtp_unconfigured.value:
+            # This request was never emailed, so no recipient can legitimately hold its
+            # link — presenting one means it was read out of the database. Refuse it
+            # rather than let an operator submit the form as the recipient. The message
+            # stays generic: this endpoint is unauthenticated and must not disclose the
+            # tenant's mail configuration.
+            LOGGER.warning(
+                "external-form: refused a request parked as smtp_unconfigured"
+                " (id=%s instance=%s task=%s); it was never delivered to its recipient.",
+                row.id,
+                row.process_instance_id,
+                row.task_guid,
+            )
+            raise ApiError(
+                error_code="reference_not_active",
+                message="This link is not active.",
+                status_code=409,
             )
 
     @classmethod
@@ -260,7 +283,9 @@ class ExternalFormService:
             ExternalFormRequestModel.process_instance_id == row.process_instance_id,
             ExternalFormRequestModel.task_guid == row.task_guid,
             ExternalFormRequestModel.id != row.id,
-            ExternalFormRequestModel.status.in_(ACTIONABLE_STATUSES),
+            # OPEN, not ACTIONABLE: a sibling parked for missing SMTP must be superseded
+            # too, or configuring SMTP later would email a link for an already-done task.
+            ExternalFormRequestModel.status.in_(OPEN_STATUSES),
         ).all()
         for sibling in siblings:
             sibling.status = ExternalFormRequestStatus.superseded.value

--- a/m8flow-backend/tests/unit/m8flow_backend/models/test_external_form_request.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/models/test_external_form_request.py
@@ -27,10 +27,14 @@ for path in (extension_src, backend_src):
 
 from m8flow_backend.models.external_form_request import (  # noqa: E402
     ACTIONABLE_STATUSES,
+    OPEN_STATUSES,
     ExternalFormRequestModel,
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+    ProcessModelBpmnVersionModel,
+)
 from spiffworkflow_backend.models.db import db  # noqa: E402
 from spiffworkflow_backend.models.db import add_listeners  # noqa: E402
 from spiffworkflow_backend.models.user import UserModel  # noqa: E402
@@ -133,6 +137,45 @@ class TestExternalFormRequestModel:
         assert ExternalFormRequestStatus.failed.value in ACTIONABLE_STATUSES
         assert ExternalFormRequestStatus.completed.value not in ACTIONABLE_STATUSES
         assert ExternalFormRequestStatus.superseded.value not in ACTIONABLE_STATUSES
+
+    def test_smtp_unconfigured_is_open_but_not_actionable(self, app, tenant, recipient):
+        """The three-tier split that makes the fix work.
+
+        Out of CLAIMABLE (checked in the service tests) the sweep stops re-picking the row.
+        Out of ACTIONABLE the never-delivered link cannot be submitted. Still in OPEN it
+        keeps suppressing duplicate rows, expiring on TTL, and being superseded.
+        """
+        parked = ExternalFormRequestStatus.smtp_unconfigured.value
+
+        assert parked not in ACTIONABLE_STATUSES
+        assert parked in OPEN_STATUSES
+        assert set(ACTIONABLE_STATUSES).issubset(set(OPEN_STATUSES))
+
+        row = _make_request_row(tenant, recipient)
+        row.status = parked
+        assert row.is_actionable() is False
+
+    def test_to_admin_dict_withholds_the_reference_id(self, app, tenant, recipient):
+        """reference_id is the bearer credential in the emailed secure link, so the admin
+        serializer must not carry it. Admin actions key on id instead."""
+        row = _make_request_row(tenant, recipient)
+        db.session.add(row)
+        db.session.commit()
+
+        payload = row.to_admin_dict()
+
+        assert "reference_id" not in payload
+        assert payload["id"] == row.id
+        # Diagnostic fields an admin needs to answer "did it fail, and why".
+        for field in ("status", "attempts", "last_error", "email", "notified_at_in_seconds"):
+            assert field in payload
+
+    def test_last_error_defaults_to_none(self, app, tenant, recipient):
+        row = _make_request_row(tenant, recipient)
+        db.session.add(row)
+        db.session.commit()
+
+        assert row.last_error is None
 
     def test_form_submission_data_json_roundtrip(self, app, tenant, recipient):
         row = _make_request_row(tenant, recipient)

--- a/m8flow-backend/tests/unit/m8flow_backend/models/test_external_form_request.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/models/test_external_form_request.py
@@ -32,7 +32,7 @@ from m8flow_backend.models.external_form_request import (  # noqa: E402
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
-from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: E402, F401
     ProcessModelBpmnVersionModel,
 )
 from spiffworkflow_backend.models.db import db  # noqa: E402

--- a/m8flow-backend/tests/unit/m8flow_backend/routes/test_external_form_notifications_controller.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/routes/test_external_form_notifications_controller.py
@@ -1,0 +1,323 @@
+"""Unit tests for the external-form notifications admin controller.
+
+Tests cover:
+- external_form_smtp_status: configured / missing-secret reporting, no secret values in
+  the payload, super admin must name a tenant
+- external_form_notification_list: pagination, status and instance filters, per_page cap,
+  reference_id withheld (it is the recipient's bearer credential), super-admin tenant
+  labelling and cross-tenant isolation
+- external_form_notification_resend: requeue, 404 for another tenant's row, 409 for a
+  status that cannot be resent, super admin must name a tenant
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+# Setup path for imports
+extension_root = Path(__file__).resolve().parents[4]
+repo_root = extension_root.parent
+extension_src = extension_root / "src"
+backend_src = repo_root / "spiffworkflow-backend" / "src"
+
+for path in (extension_src, backend_src):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+from spiffworkflow_backend.models.db import db  # noqa: E402
+from spiffworkflow_backend.models.db import add_listeners  # noqa: E402
+from spiffworkflow_backend.models.user import UserModel  # noqa: E402
+
+from m8flow_backend.models.external_form_request import (  # noqa: E402
+    ExternalFormRequestModel,
+    ExternalFormRequestStatus,
+)
+from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+    ProcessModelBpmnVersionModel,
+)
+from m8flow_backend.routes import external_form_notifications_controller as controller  # noqa: E402
+from m8flow_backend.services.external_form_notification_service import (  # noqa: E402
+    ExternalFormNotificationService,
+)
+from m8flow_backend.services.external_form_service import ExternalFormService  # noqa: E402
+
+TASK_GUID = "11111111-2222-3333-4444-555555555555"
+
+DEFAULT_SMTP_SECRETS = {
+    "NATS_SMTP_HOST": "smtp.test",
+    "NATS_SMTP_FROM_EMAIL": "no-reply@tenant-one.example",
+}
+
+
+@pytest.fixture(autouse=True)
+def _link_ttl_env(monkeypatch):
+    monkeypatch.setenv("M8FLOW_EXTERNAL_FORM_LINK_TTL_SECONDS", "604800")
+
+
+@pytest.fixture
+def app():
+    """Create Flask app with in-memory database for testing."""
+    app = Flask(__name__)  # NOSONAR - unit test with in-memory DB, no HTTP/CSRF involved
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] = "sqlite"
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        add_listeners()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _make_tenant(tenant_id: str, name: str, slug: str) -> M8flowTenantModel:
+    tenant = M8flowTenantModel(
+        id=tenant_id,
+        name=name,
+        slug=slug,
+        status=TenantStatus.ACTIVE,
+        created_by="admin",
+        modified_by="admin",
+    )
+    db.session.add(tenant)
+    db.session.commit()
+    return tenant
+
+
+@pytest.fixture
+def tenant(app):
+    return _make_tenant("tenant-1", "Tenant One", "tenant-one")
+
+
+@pytest.fixture
+def other_tenant(app):
+    return _make_tenant("tenant-2", "Tenant Two", "tenant-two")
+
+
+@pytest.fixture
+def alice(app):
+    user = UserModel(username="alice", service="test", service_id="alice", email="alice@example.com")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture
+def smtp_secrets(monkeypatch):
+    """Stub the per-tenant SMTP secret lookup with a mutable dict (default: configured)."""
+    secrets = dict(DEFAULT_SMTP_SECRETS)
+    monkeypatch.setattr(
+        ExternalFormNotificationService,
+        "_read_tenant_secret",
+        staticmethod(lambda key: secrets.get(key)),
+    )
+    monkeypatch.setattr(
+        ExternalFormNotificationService,
+        "_read_secret_for_tenant",
+        classmethod(lambda cls, key, tenant_id: secrets.get(key)),
+    )
+    return secrets
+
+
+@pytest.fixture
+def not_super_admin(monkeypatch):
+    monkeypatch.setattr(controller, "is_super_admin_request", lambda: False)
+
+
+@pytest.fixture
+def super_admin(monkeypatch):
+    monkeypatch.setattr(controller, "is_super_admin_request", lambda: True)
+
+
+def _create_request(tenant, user, **kwargs):
+    defaults = {
+        "tenant_id": tenant.id,
+        "process_instance_id": 42,
+        "task_guid": TASK_GUID,
+        "external_form_url": "https://forms.example.com/leave-request",
+        "recipients": [{"user_id": user.id, "email": user.email, "user_details": {"username": user.username}}],
+    }
+    defaults.update(kwargs)
+    return ExternalFormService.create_requests_for_task(**defaults)[0]
+
+
+class TestSmtpStatus:
+    def test_reports_configured_tenant(self, app, tenant, smtp_secrets, not_super_admin):
+        with app.test_request_context("/"):
+            response = controller.external_form_smtp_status()
+
+        assert response.status_code == 200
+        assert response.get_json()["configured"] is True
+
+    def test_names_the_missing_secrets(self, app, tenant, smtp_secrets, not_super_admin):
+        smtp_secrets.clear()
+
+        with app.test_request_context("/"):
+            payload = controller.external_form_smtp_status().get_json()
+
+        assert payload["configured"] is False
+        assert set(payload["missing_required_keys"]) == {"NATS_SMTP_HOST", "NATS_SMTP_FROM_EMAIL"}
+        assert "NATS_SMTP_PASSWORD" in payload["optional_keys"]
+        assert payload["reason"]
+
+    def test_never_returns_a_secret_value(self, app, tenant, smtp_secrets, not_super_admin):
+        with app.test_request_context("/"):
+            body = controller.external_form_smtp_status().get_data(as_text=True)
+
+        assert "smtp.test" not in body
+        assert "no-reply@tenant-one.example" not in body
+
+    def test_super_admin_must_name_a_tenant(self, app, tenant, smtp_secrets, super_admin):
+        """Without a tenant the query spans every tenant, so a configured *other* tenant
+        would make this one look configured."""
+        with app.test_request_context("/"):
+            response = controller.external_form_smtp_status()
+
+        assert response.status_code == 400
+        assert response.get_json()["error_code"] == "tenant_id_required"
+
+    def test_super_admin_with_tenant_id_is_answered(self, app, tenant, smtp_secrets, super_admin):
+        with app.test_request_context(f"/?tenantId={tenant.id}"):
+            response = controller.external_form_smtp_status()
+
+        assert response.status_code == 200
+        assert response.get_json()["configured"] is True
+
+
+class TestNotificationList:
+    def test_returns_rows_for_the_active_tenant(self, app, tenant, alice, not_super_admin):
+        row = _create_request(tenant, alice)
+
+        with app.test_request_context("/"):
+            payload = controller.external_form_notification_list().get_json()
+
+        assert payload["pagination"]["total"] == 1
+        assert payload["results"][0]["id"] == row.id
+        assert payload["results"][0]["status"] == ExternalFormRequestStatus.pending.value
+
+    def test_withholds_the_reference_id(self, app, tenant, alice, not_super_admin):
+        """reference_id is the bearer credential in the emailed link; exposing it here
+        would let an admin submit the form as the recipient."""
+        row = _create_request(tenant, alice)
+
+        with app.test_request_context("/"):
+            response = controller.external_form_notification_list()
+
+        assert "reference_id" not in response.get_json()["results"][0]
+        assert row.reference_id not in response.get_data(as_text=True)
+
+    def test_surfaces_the_park_reason(self, app, tenant, alice, not_super_admin):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "missing NATS_SMTP_HOST")
+
+        with app.test_request_context("/"):
+            result = controller.external_form_notification_list().get_json()["results"][0]
+
+        assert result["status"] == ExternalFormRequestStatus.smtp_unconfigured.value
+        assert result["last_error"] == "missing NATS_SMTP_HOST"
+
+    def test_filters_by_status(self, app, tenant, alice, not_super_admin):
+        parked = _create_request(tenant, alice)
+        _create_request(tenant, alice, task_guid="99999999-2222-3333-4444-555555555555")
+        ExternalFormNotificationService.mark_smtp_unconfigured([parked.id], "no smtp")
+
+        with app.test_request_context("/"):
+            payload = controller.external_form_notification_list(
+                status=ExternalFormRequestStatus.smtp_unconfigured.value
+            ).get_json()
+
+        assert [row["id"] for row in payload["results"]] == [parked.id]
+
+    def test_filters_by_process_instance(self, app, tenant, alice, not_super_admin):
+        mine = _create_request(tenant, alice)
+        _create_request(tenant, alice, process_instance_id=77, task_guid="88888888-2222-3333-4444-555555555555")
+
+        with app.test_request_context("/"):
+            payload = controller.external_form_notification_list(process_instance_id=42).get_json()
+
+        assert [row["id"] for row in payload["results"]] == [mine.id]
+
+    def test_per_page_is_capped(self, app, tenant, alice, not_super_admin):
+        _create_request(tenant, alice)
+
+        with app.test_request_context("/"):
+            payload = controller.external_form_notification_list(per_page=10_000).get_json()
+
+        # Cap applied rather than honouring an unbounded page.
+        assert payload["pagination"]["count"] == 1
+
+    def test_super_admin_scoped_to_one_tenant(self, app, tenant, other_tenant, alice, super_admin):
+        mine = _create_request(tenant, alice)
+        theirs = _create_request(other_tenant, alice, process_instance_id=99)
+
+        with app.test_request_context(f"/?tenantId={tenant.id}"):
+            payload = controller.external_form_notification_list().get_json()
+
+        ids = [row["id"] for row in payload["results"]]
+        assert mine.id in ids
+        assert theirs.id not in ids
+        assert payload["results"][0]["tenantName"] == "Tenant One"
+
+
+class TestNotificationResend:
+    def test_requeues_a_parked_row(self, app, tenant, alice, not_super_admin):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        with app.test_request_context("/", method="POST"):
+            response = controller.external_form_notification_resend(row.id)
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == ExternalFormRequestStatus.pending.value
+        refreshed = db.session.get(ExternalFormRequestModel, row.id)
+        assert refreshed.status == ExternalFormRequestStatus.pending.value
+        assert refreshed.last_error is None
+
+    def test_unknown_id_is_404(self, app, tenant, not_super_admin):
+        with app.test_request_context("/", method="POST"):
+            response = controller.external_form_notification_resend(4242)
+
+        assert response.status_code == 404
+        assert response.get_json()["error_code"] == "external_form_request_not_found"
+
+    def test_submitted_row_is_409(self, app, tenant, alice, not_super_admin):
+        row = _create_request(tenant, alice)
+        stored = db.session.get(ExternalFormRequestModel, row.id)
+        stored.status = ExternalFormRequestStatus.submitted.value
+        db.session.commit()
+
+        with app.test_request_context("/", method="POST"):
+            response = controller.external_form_notification_resend(row.id)
+
+        assert response.status_code == 409
+        assert response.get_json()["error_code"] == "external_form_request_not_resendable"
+
+    def test_super_admin_must_name_a_tenant(self, app, tenant, alice, super_admin):
+        """request_id is a bare integer, so without a tenant it would address any tenant."""
+        row = _create_request(tenant, alice)
+
+        with app.test_request_context("/", method="POST"):
+            response = controller.external_form_notification_resend(row.id)
+
+        assert response.status_code == 400
+        assert response.get_json()["error_code"] == "tenant_id_required"
+
+    def test_super_admin_cannot_resend_another_tenants_row(
+        self, app, tenant, other_tenant, alice, super_admin
+    ):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        with app.test_request_context(f"/?tenantId={other_tenant.id}", method="POST"):
+            response = controller.external_form_notification_resend(row.id)
+
+        assert response.status_code == 404
+        assert db.session.get(ExternalFormRequestModel, row.id).status == (
+            ExternalFormRequestStatus.smtp_unconfigured.value
+        )

--- a/m8flow-backend/tests/unit/m8flow_backend/routes/test_external_form_notifications_controller.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/routes/test_external_form_notifications_controller.py
@@ -37,7 +37,7 @@ from m8flow_backend.models.external_form_request import (  # noqa: E402
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
-from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: E402, F401
     ProcessModelBpmnVersionModel,
 )
 from m8flow_backend.routes import external_form_notifications_controller as controller  # noqa: E402

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
@@ -41,7 +41,7 @@ from m8flow_backend.models.external_form_request import (  # noqa: E402
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
-from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: E402, F401
     ProcessModelBpmnVersionModel,
 )
 from m8flow_backend.services.external_form_notification_service import (  # noqa: E402

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
@@ -573,8 +573,31 @@ class TestSmtpReadiness:
         assert status["configured"] is True
         assert status["required_keys"] == ["NATS_SMTP_HOST", "NATS_SMTP_FROM_EMAIL"]
         assert "NATS_SMTP_PASSWORD" in status["optional_keys"]
+        assert status["missing_required_keys"] == []
+        assert status["unreadable_keys"] == []
         # No secret value may appear anywhere in the payload.
         assert "smtp.test" not in repr(status)
+
+    def test_configuration_status_distinguishes_missing_from_unreadable(self, app, tenant, monkeypatch):
+        # Present in DB (so key exists), but decrypt returns None (unreadable).
+        monkeypatch.setattr(
+            ExternalFormNotificationService,
+            "_present_smtp_secret_keys",
+            staticmethod(lambda tenant_id=None: {"NATS_SMTP_FROM_EMAIL"}),
+        )
+        monkeypatch.setattr(
+            ExternalFormNotificationService,
+            "_read_secret_for_tenant",
+            staticmethod(lambda key, tenant_id=None: None),
+        )
+
+        status = ExternalFormNotificationService.smtp_configuration_status()
+
+        assert status["configured"] is False
+        # NATS_SMTP_HOST is absent from DB -> missing
+        assert status["missing_required_keys"] == ["NATS_SMTP_HOST"]
+        # NATS_SMTP_FROM_EMAIL is present in DB but unreadable -> unreadable, not missing
+        assert status["unreadable_keys"] == ["NATS_SMTP_FROM_EMAIL"]
 
     def test_required_keys_match_resolve_smtp_settings(self, app, tenant, smtp_secrets):
         """Guards the single-source-of-truth invariant: if these drift, the API would

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py
@@ -8,6 +8,9 @@ Tests cover:
   excludes resume-failed (notified_at set), expired, exhausted, fresh rows
 - build_secure_link: ref= appended preserving query params; mini-app base override
 - notify: end-to-end with SMTP mocked, failure recording and retry
+- smtp_readiness / smtp_configuration_status: missing vs unreadable required secrets
+- mark_smtp_unconfigured / revive_smtp_unconfigured / requeue: the terminal park that
+  stops the indefinite retry loop, and the paths back out of it
 """
 import logging
 import sys
@@ -33,10 +36,14 @@ from spiffworkflow_backend.models.db import add_listeners  # noqa: E402
 from spiffworkflow_backend.models.user import UserModel  # noqa: E402
 
 from m8flow_backend.models.external_form_request import (  # noqa: E402
+    LAST_ERROR_MAX_LENGTH,
     ExternalFormRequestModel,
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+    ProcessModelBpmnVersionModel,
+)
 from m8flow_backend.services.external_form_notification_service import (  # noqa: E402
     ExternalFormNotificationService,
 )
@@ -78,6 +85,10 @@ def app():
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] = "sqlite"
+    app.config["SPIFFWORKFLOW_BACKEND_ENCRYPTION_LIB"] = "no_op_cipher"
+    from spiffworkflow_backend.config import NoOpCipher
+
+    app.config["CIPHER"] = NoOpCipher()
     db.init_app(app)
 
     with app.app_context():
@@ -217,8 +228,9 @@ class TestReleaseFailed:
         row = _fresh(row.id)
         assert row.status == ExternalFormRequestStatus.failed.value
         assert row.notified_at_in_seconds is None
-        # Failure reason is logged (not stored on the row).
+        # Failure reason is both logged and persisted for the admin UI.
         assert "connection refused" in caplog.text
+        assert row.last_error == "connection refused"
 
     def test_does_not_clobber_submitted_row(self, app, tenant, alice):
         row = _create_request(tenant, alice)
@@ -356,8 +368,9 @@ class TestNotify:
         row = _fresh(row.id)
         assert row.status == ExternalFormRequestStatus.failed.value
         assert row.notified_at_in_seconds is None
-        # Failure reason is logged (not stored on the row).
+        # Failure reason is both logged and persisted for the admin UI.
         assert "smtp down" in caplog.text
+        assert row.last_error is not None and "smtp down" in row.last_error
 
         fake_smtp.fail_with = None
         assert ExternalFormNotificationService.notify(row.reference_id) == "sent"
@@ -366,19 +379,68 @@ class TestNotify:
     def test_unknown_reference(self, app):
         assert ExternalFormNotificationService.notify("no-such-ref") == "skipped:unknown_reference"
 
-    def test_unconfigured_smtp_leaves_row_pending(self, app, tenant, alice, fake_smtp, smtp_secrets):
+    def test_unconfigured_smtp_parks_row_as_terminal(self, app, tenant, alice, fake_smtp, smtp_secrets, caplog):
+        """The regression test for the indefinite retry loop.
+
+        Leaving the row 'pending' meant claim() never ran, so attempts stayed 0 and
+        sweep_candidates re-selected it every interval for the link's whole TTL."""
         smtp_secrets.clear()  # tenant has no SMTP secrets
         row = _create_request(tenant, alice)
 
-        assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:smtp_unconfigured"
-        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+        with caplog.at_level(logging.ERROR):
+            assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:smtp_unconfigured"
+
+        parked = _fresh(row.id)
+        assert parked.status == ExternalFormRequestStatus.smtp_unconfigured.value
+        assert parked.last_error is not None
+        assert "NATS_SMTP_HOST" in parked.last_error
+        assert fake_smtp.sent_messages == []
+        # Logged once, with the identifiers an admin needs and no secret values.
+        assert "smtp_unconfigured" in caplog.text
+        assert str(tenant.id) in caplog.text
+
+    def test_parked_row_is_not_swept_again(self, app, tenant, alice, fake_smtp, smtp_secrets, monkeypatch):
+        """A parked row must fall out of sweep_candidates entirely — this is what ends the
+        retry loop. Asserted against the query itself, not only via notify()."""
+        monkeypatch.setenv("M8FLOW_NOTIFICATION_SWEEP_GRACE_SECONDS", "0")
+        smtp_secrets.clear()
+        row = _create_request(tenant, alice)
+        now = int(time.time()) + 1000
+
+        # Owed an email before the park...
+        assert row.id in [candidate[0] for candidate in ExternalFormNotificationService.sweep_candidates(now=now)]
+
+        ExternalFormNotificationService.notify(row.reference_id)
+
+        # ...and invisible to every subsequent sweep.
+        assert ExternalFormNotificationService.sweep_candidates(now=now) == []
+
+
+    def test_redelivered_event_cannot_email_a_parked_row(
+        self, app, tenant, alice, fake_smtp, smtp_secrets
+    ):
+        """A parked row is outside CLAIMABLE_STATUSES, so the NATS fast path cannot email
+        it even after SMTP is configured. Recovery must go through revive/resend, which is
+        what keeps the parked state authoritative while events are still in flight."""
+        smtp_secrets.clear()
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.notify(row.reference_id)
+        assert _fresh(row.id).status == ExternalFormRequestStatus.smtp_unconfigured.value
+
+        smtp_secrets.update(DEFAULT_SMTP_SECRETS)
+
+        assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:not_claimable"
+        assert fake_smtp.sent_messages == []
+        assert _fresh(row.id).status == ExternalFormRequestStatus.smtp_unconfigured.value
 
     def test_missing_from_email_is_unconfigured(self, app, tenant, alice, fake_smtp, smtp_secrets):
         del smtp_secrets["NATS_SMTP_FROM_EMAIL"]  # host present but no sender address
         row = _create_request(tenant, alice)
 
         assert ExternalFormNotificationService.notify(row.reference_id) == "skipped:smtp_unconfigured"
-        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+        parked = _fresh(row.id)
+        assert parked.status == ExternalFormRequestStatus.smtp_unconfigured.value
+        assert "NATS_SMTP_FROM_EMAIL" in parked.last_error
 
     def test_expired_row_is_not_emailed(self, app, tenant, alice, fake_smtp, smtp_secrets):
         row = _create_request(tenant, alice, expires_at_in_seconds=int(time.time()) - 10)
@@ -395,8 +457,9 @@ class TestNotify:
         assert fake_smtp.sent_messages == []
         row = _fresh(row.id)
         assert row.status == ExternalFormRequestStatus.failed.value
-        # Failure reason is logged (not stored on the row).
+        # Failure reason is both logged and persisted for the admin UI.
         assert "not http/https" in caplog.text
+        assert row.last_error is not None and "not http/https" in row.last_error
 
 
 class TestRenderEmail:
@@ -449,3 +512,235 @@ class TestRenderEmail:
 
         assert "<script>" not in html_body
         assert "&amp;" in html_body
+
+
+def _add_secret(tenant_id: str, key: str, raw_value: str) -> None:
+    """Write a real encrypted SecretModel row so the presence query sees it."""
+    from spiffworkflow_backend.models.secret_model import SecretModel
+    from spiffworkflow_backend.services.secret_service import SecretService
+
+    secret = SecretModel(key=key, value=SecretService._encrypt(raw_value), user_id=1)
+    secret.m8f_tenant_id = tenant_id
+    db.session.add(secret)
+    db.session.commit()
+
+
+class TestSmtpReadiness:
+    """Missing vs unreadable required secrets.
+
+    Both block sending but need opposite fixes -- re-entering a key does not help when the
+    stored value cannot be decrypted -- so the reason must never collapse them.
+    """
+
+    def test_no_secrets_reports_every_required_key_missing(self, app, tenant, smtp_secrets):
+        smtp_secrets.clear()
+
+        readiness = ExternalFormNotificationService.smtp_readiness()
+
+        assert readiness["ok"] is False
+        assert set(readiness["missing"]) == {"NATS_SMTP_HOST", "NATS_SMTP_FROM_EMAIL"}
+        assert readiness["unreadable"] == []
+        assert "Missing required secrets" in readiness["reason"]
+
+    def test_configured_tenant_is_ok(self, app, tenant, smtp_secrets):
+        readiness = ExternalFormNotificationService.smtp_readiness()
+
+        assert readiness["ok"] is True
+        assert readiness["unusable"] == []
+        assert readiness["reason"] is None
+
+    def test_present_but_blank_secret_is_unreadable_not_missing(self, app, tenant, monkeypatch):
+        """A row exists yet resolves to nothing. Reporting it as missing would send the
+        admin to re-enter a key that is already there."""
+        _add_secret(tenant.id, "NATS_SMTP_HOST", "smtp.test")
+        _add_secret(tenant.id, "NATS_SMTP_FROM_EMAIL", "   ")
+        monkeypatch.setattr(
+            ExternalFormNotificationService,
+            "_read_tenant_secret",
+            staticmethod(lambda key: {"NATS_SMTP_HOST": "smtp.test"}.get(key)),
+        )
+
+        readiness = ExternalFormNotificationService.smtp_readiness()
+
+        assert readiness["ok"] is False
+        assert readiness["missing"] == []
+        assert readiness["unreadable"] == ["NATS_SMTP_FROM_EMAIL"]
+        assert "encryption key changed" in readiness["reason"]
+
+    def test_configuration_status_returns_names_never_values(self, app, tenant, smtp_secrets):
+        status = ExternalFormNotificationService.smtp_configuration_status()
+
+        assert status["configured"] is True
+        assert status["required_keys"] == ["NATS_SMTP_HOST", "NATS_SMTP_FROM_EMAIL"]
+        assert "NATS_SMTP_PASSWORD" in status["optional_keys"]
+        # No secret value may appear anywhere in the payload.
+        assert "smtp.test" not in repr(status)
+
+    def test_required_keys_match_resolve_smtp_settings(self, app, tenant, smtp_secrets):
+        """Guards the single-source-of-truth invariant: if these drift, the API would
+        report a tenant as configured when it still cannot send."""
+        for key in ExternalFormNotificationService.smtp_configuration_status()["required_keys"]:
+            secrets = dict(DEFAULT_SMTP_SECRETS)
+            del secrets[key]
+            smtp_secrets.clear()
+            smtp_secrets.update(secrets)
+            assert ExternalFormNotificationService.resolve_smtp_settings() is None
+
+
+class TestMarkSmtpUnconfigured:
+    def test_parks_pending_rows(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+
+        assert ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp") == 1
+        parked = _fresh(row.id)
+        assert parked.status == ExternalFormRequestStatus.smtp_unconfigured.value
+        assert parked.last_error == "no smtp"
+
+    def test_does_not_clobber_claimed_row(self, app, tenant, alice):
+        """Mirrors the release_failed guard: another worker already owns this row."""
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.claim(row.id)
+
+        assert ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp") == 0
+        assert _fresh(row.id).status == ExternalFormRequestStatus.notified.value
+
+    def test_does_not_clobber_submitted_row(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        row = _fresh(row.id)
+        row.status = ExternalFormRequestStatus.submitted.value
+        db.session.commit()
+
+        assert ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp") == 0
+        assert _fresh(row.id).status == ExternalFormRequestStatus.submitted.value
+
+    def test_empty_id_list_is_a_noop(self, app, tenant):
+        assert ExternalFormNotificationService.mark_smtp_unconfigured([], "no smtp") == 0
+
+    def test_long_reason_is_truncated_to_the_column(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "x" * 5000)
+
+        assert len(_fresh(row.id).last_error) == LAST_ERROR_MAX_LENGTH
+
+
+class TestReviveSmtpUnconfigured:
+    def test_bulk_revive_requires_tenant_id(self, app, tenant, alice):
+        """UPDATEs bypass the tenant-scoping SELECT listener, so an unscoped bulk revive
+        would unpark every tenant's rows."""
+        with pytest.raises(ValueError, match="requires tenant_id"):
+            ExternalFormNotificationService.revive_smtp_unconfigured()
+
+    def test_revives_parked_rows_and_resets_attempts(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        assert ExternalFormNotificationService.revive_smtp_unconfigured(tenant_id=tenant.id) == 1
+        revived = _fresh(row.id)
+        assert revived.status == ExternalFormRequestStatus.pending.value
+        assert revived.notified_at_in_seconds is None
+        # The parked attempts burned no SMTP connection, so they must not count.
+        assert revived.attempts == 0
+        assert revived.last_error is None
+
+    def test_leaves_other_tenants_parked_rows_alone(self, app, tenant, alice):
+        other = M8flowTenantModel(
+            id="tenant-2",
+            name="Tenant Two",
+            slug="tenant-two",
+            status=TenantStatus.ACTIVE,
+            created_by="admin",
+            modified_by="admin",
+        )
+        db.session.add(other)
+        db.session.commit()
+        mine = _create_request(tenant, alice)
+        theirs = _create_request(other, alice, process_instance_id=99)
+        ExternalFormNotificationService.mark_smtp_unconfigured([mine.id, theirs.id], "no smtp")
+
+        assert ExternalFormNotificationService.revive_smtp_unconfigured(tenant_id=tenant.id) == 1
+
+        assert _fresh(mine.id).status == ExternalFormRequestStatus.pending.value
+        assert _fresh(theirs.id).status == ExternalFormRequestStatus.smtp_unconfigured.value
+
+    def test_does_not_touch_non_parked_rows(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+
+        assert ExternalFormNotificationService.revive_smtp_unconfigured(tenant_id=tenant.id) == 0
+        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+
+    def test_tenants_with_parked_requests(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        assert ExternalFormNotificationService.tenants_with_parked_requests() == []
+
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        assert ExternalFormNotificationService.tenants_with_parked_requests() == [tenant.id]
+
+    def test_revived_row_is_delivered_on_the_next_sweep(
+        self, app, tenant, alice, fake_smtp, smtp_secrets, monkeypatch
+    ):
+        """End-to-end recovery: park while unconfigured, then deliver once fixed."""
+        monkeypatch.setenv("M8FLOW_NOTIFICATION_SWEEP_GRACE_SECONDS", "0")
+        smtp_secrets.clear()
+        row = _create_request(tenant, alice)
+        now = int(time.time()) + 1000
+        ExternalFormNotificationService.notify(row.reference_id)
+        assert _fresh(row.id).status == ExternalFormRequestStatus.smtp_unconfigured.value
+
+        smtp_secrets.update(DEFAULT_SMTP_SECRETS)
+        ExternalFormNotificationService.revive_smtp_unconfigured(tenant_id=tenant.id)
+
+        assert row.id in [candidate[0] for candidate in ExternalFormNotificationService.sweep_candidates(now=now)]
+        assert ExternalFormNotificationService.notify(row.reference_id) == "sent"
+        assert len(fake_smtp.sent_messages) == 1
+
+
+class TestRequeue:
+    def test_requeues_a_parked_row(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        assert ExternalFormNotificationService.requeue(row.id, tenant_id=tenant.id) is True
+        requeued = _fresh(row.id)
+        assert requeued.status == ExternalFormRequestStatus.pending.value
+        assert requeued.attempts == 0
+        assert requeued.last_error is None
+
+    def test_requeues_a_failed_send(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.claim(row.id)
+        ExternalFormNotificationService.release_failed(row.id, "smtp down")
+
+        assert ExternalFormNotificationService.requeue(row.id, tenant_id=tenant.id) is True
+        assert _fresh(row.id).status == ExternalFormRequestStatus.pending.value
+
+    def test_refuses_a_failed_resume(self, app, tenant, alice):
+        """A failed row that still has notified_at set is a failed workflow *resume*, not a
+        failed send. It was already emailed, so re-emailing it is wrong."""
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.claim(row.id)
+        row = _fresh(row.id)
+        row.status = ExternalFormRequestStatus.failed.value
+        db.session.commit()
+        assert _fresh(row.id).notified_at_in_seconds is not None
+
+        assert ExternalFormNotificationService.requeue(row.id, tenant_id=tenant.id) is False
+        assert _fresh(row.id).status == ExternalFormRequestStatus.failed.value
+
+    def test_refuses_a_submitted_row(self, app, tenant, alice):
+        row = _create_request(tenant, alice)
+        row = _fresh(row.id)
+        row.status = ExternalFormRequestStatus.submitted.value
+        db.session.commit()
+
+        assert ExternalFormNotificationService.requeue(row.id, tenant_id=tenant.id) is False
+
+    def test_tenant_id_pins_the_update(self, app, tenant, alice):
+        """request_id is a bare integer, so without the filter a super admin could requeue
+        any tenant's row."""
+        row = _create_request(tenant, alice)
+        ExternalFormNotificationService.mark_smtp_unconfigured([row.id], "no smtp")
+
+        assert ExternalFormNotificationService.requeue(row.id, tenant_id="tenant-other") is False
+        assert _fresh(row.id).status == ExternalFormRequestStatus.smtp_unconfigured.value

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_service.py
@@ -38,7 +38,7 @@ from m8flow_backend.models.external_form_request import (  # noqa: E402
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
-from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: E402, F401
     ProcessModelBpmnVersionModel,
 )
 from m8flow_backend.services.external_form_service import ExternalFormService  # noqa: E402

--- a/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_service.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_service.py
@@ -38,6 +38,9 @@ from m8flow_backend.models.external_form_request import (  # noqa: E402
     ExternalFormRequestStatus,
 )
 from m8flow_backend.models.m8flow_tenant import M8flowTenantModel, TenantStatus  # noqa: E402
+from m8flow_backend.models.process_model_bpmn_version import (  # noqa: F401
+    ProcessModelBpmnVersionModel,
+)
 from m8flow_backend.services.external_form_service import ExternalFormService  # noqa: E402
 from m8flow_backend.tenancy import get_context_tenant_id  # noqa: E402
 
@@ -334,3 +337,83 @@ class TestSubmit:
 
         assert exc_info.value.error_code == "recipient_not_found"
         assert exc_info.value.status_code == 410
+
+
+class TestParkedRequests:
+    """Behaviour for rows parked as smtp_unconfigured.
+
+    Such a row is in OPEN_STATUSES but not ACTIONABLE_STATUSES: it is still the live
+    request for its (task, recipient) pair, yet its link was never delivered to anyone.
+    """
+
+    @staticmethod
+    def _park(row):
+        row = db.session.get(ExternalFormRequestModel, row.id)
+        row.status = ExternalFormRequestStatus.smtp_unconfigured.value
+        db.session.commit()
+        return row
+
+    def test_parked_row_suppresses_duplicate_creation(self, app, tenant, alice):
+        """OPEN, not ACTIONABLE: otherwise every processor.save() would add another row,
+        and configuring SMTP later would email the recipient all of them at once."""
+        (first,) = _create_requests(tenant, alice)
+        self._park(first)
+
+        rows = _create_requests(tenant, alice)
+
+        assert rows == []
+        assert ExternalFormRequestModel.query.count() == 1
+
+    def test_parked_row_still_expires_on_ttl(self, app, tenant, alice):
+        """Otherwise a parked request would sit outside every terminal check forever."""
+        (row,) = _create_requests(tenant, alice, expires_at_in_seconds=int(time.time()) - 10)
+        self._park(row)
+
+        with app.test_request_context():
+            context = ExternalFormService.get_form_context(row.reference_id)
+
+        assert context["actionable"] is False
+        assert db.session.get(ExternalFormRequestModel, row.id).status == (
+            ExternalFormRequestStatus.expired.value
+        )
+
+    def test_parked_row_is_not_actionable(self, app, tenant, alice):
+        (row,) = _create_requests(tenant, alice)
+        parked = self._park(row)
+
+        assert parked.is_actionable() is False
+
+    def test_submitting_a_parked_link_is_refused(self, app, tenant, alice, caplog):
+        """The link was never emailed, so presenting one means it was read out of the
+        database. Accepting it would let an operator submit as the recipient."""
+        (row,) = _create_requests(tenant, alice)
+        self._park(row)
+
+        with app.test_request_context():
+            with caplog.at_level(logging.WARNING):
+                with pytest.raises(ApiError) as exc_info:
+                    ExternalFormService.submit(row.reference_id, {"answer": 1})
+
+        assert exc_info.value.error_code == "reference_not_active"
+        assert exc_info.value.status_code == 409
+        # The message must not disclose the tenant mail configuration on a public endpoint.
+        assert "SMTP" not in exc_info.value.message
+        assert "smtp_unconfigured" in caplog.text
+        assert db.session.get(ExternalFormRequestModel, row.id).status == (
+            ExternalFormRequestStatus.smtp_unconfigured.value
+        )
+
+    def test_parked_sibling_is_superseded_by_a_submission(self, app, tenant, alice, bob, monkeypatch):
+        """Otherwise configuring SMTP later would email a link for an already-done task."""
+        alice_row, bob_row = _create_requests(tenant, alice, bob)
+        self._park(bob_row)
+        monkeypatch.setattr(
+            "spiffworkflow_backend.routes.process_api_blueprint._task_submit_shared", Mock(return_value={})
+        )
+
+        with app.test_request_context():
+            ExternalFormService.submit(alice_row.reference_id, {"answer": 1})
+
+        assert db.session.get(ExternalFormRequestModel, bob_row.id).status == (
+            ExternalFormRequestStatus.superseded.value
+        )

--- a/m8flow-backend/tests/unit/m8flow_backend/test_external_form_last_error_migration.py
+++ b/m8flow-backend/tests/unit/m8flow_backend/test_external_form_last_error_migration.py
@@ -1,0 +1,156 @@
+"""Unit tests for the add-last_error migration (r1k2l3m4n5o6).
+
+Tests cover:
+- upgrade adds a nullable last_error column and preserves existing rows
+- upgrade is idempotent when the column already exists
+- upgrade is a no-op when the table is absent
+- downgrade removes the column and is idempotent
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "migrations"
+    / "versions"
+    / "r1k2l3m4n5o6_add_external_form_request_last_error.py"
+)
+
+TABLE_NAME = "m8flow_external_form_requests"
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location("external_form_last_error_migration", MIGRATION_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bind_operations(module, connection: sa.Connection) -> None:
+    context = MigrationContext.configure(connection)
+    module.op = Operations(context)
+
+
+def _columns(connection: sa.Connection) -> dict[str, dict]:
+    return {column["name"]: column for column in sa.inspect(connection).get_columns(TABLE_NAME)}
+
+
+def _create_pre_migration_table(connection: sa.Connection) -> None:
+    """The table as it stood before this revision: no last_error column."""
+    connection.execute(
+        sa.text(
+            f"""
+            CREATE TABLE {TABLE_NAME} (
+                id INTEGER NOT NULL PRIMARY KEY,
+                reference_id VARCHAR(255) NOT NULL,
+                process_instance_id INTEGER NOT NULL,
+                task_guid VARCHAR(36) NOT NULL,
+                recipient_user_id INTEGER NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                external_form_url TEXT NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                attempts INTEGER NOT NULL,
+                notified_at_in_seconds INTEGER,
+                m8f_tenant_id VARCHAR(255)
+            )
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            f"""
+            INSERT INTO {TABLE_NAME}
+                (id, reference_id, process_instance_id, task_guid, recipient_user_id,
+                 email, external_form_url, status, attempts, m8f_tenant_id)
+            VALUES
+                (1, 'ref-1', 42, 'task-guid', 7, 'alice@example.com',
+                 'https://forms.example.com/f', 'pending', 0, 'tenant-1')
+            """
+        )
+    )
+
+
+@pytest.fixture
+def connection():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as connection:
+        yield connection
+
+
+def test_upgrade_adds_nullable_column_and_keeps_rows(connection):
+    module = _load_migration_module()
+    _create_pre_migration_table(connection)
+    _bind_operations(module, connection)
+
+    module.upgrade()
+
+    columns = _columns(connection)
+    assert "last_error" in columns
+    assert columns["last_error"]["nullable"] is True
+    # Existing data survives and reads back as NULL.
+    row = connection.execute(sa.text(f"SELECT id, status, last_error FROM {TABLE_NAME}")).fetchone()
+    assert row == (1, "pending", None)
+
+
+def test_upgrade_is_idempotent(connection):
+    module = _load_migration_module()
+    _create_pre_migration_table(connection)
+    _bind_operations(module, connection)
+
+    module.upgrade()
+    module.upgrade()
+
+    assert "last_error" in _columns(connection)
+
+
+def test_upgrade_is_a_noop_without_the_table(connection):
+    module = _load_migration_module()
+    _bind_operations(module, connection)
+
+    module.upgrade()
+
+    assert TABLE_NAME not in sa.inspect(connection).get_table_names()
+
+
+def test_downgrade_removes_the_column(connection):
+    module = _load_migration_module()
+    _create_pre_migration_table(connection)
+    _bind_operations(module, connection)
+    module.upgrade()
+
+    module.downgrade()
+
+    assert "last_error" not in _columns(connection)
+    # Dropping diagnostic text must not drop request state.
+    row = connection.execute(sa.text(f"SELECT id, status FROM {TABLE_NAME}")).fetchone()
+    assert row == (1, "pending")
+
+
+def test_downgrade_is_idempotent(connection):
+    module = _load_migration_module()
+    _create_pre_migration_table(connection)
+    _bind_operations(module, connection)
+    module.upgrade()
+
+    module.downgrade()
+    module.downgrade()
+
+    assert "last_error" not in _columns(connection)
+
+
+def test_revision_chains_onto_the_previous_head(connection):
+    module = _load_migration_module()
+
+    assert module.revision == "r1k2l3m4n5o6"
+    # Chains after the nats_event_audit revision, which also branches off p9i0j1k2l3m4;
+    # sharing that parent would leave Alembic with two heads.
+    assert module.down_revision == "q0j1k2l3m4n5"

--- a/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js
@@ -1,5 +1,10 @@
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 import { SpiffExtensionTextInput } from 'bpmn-js-spiffworkflow/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionTextInput';
+import { createElement } from '@bpmn-io/properties-panel/preact';
+import {
+  ExternalFormSmtpLabel,
+  ExternalFormSmtpStatus,
+} from './ExternalFormSmtpStatus';
 
 const LOW_PRIORITY = 500;
 
@@ -49,7 +54,13 @@ ExternalFormPropertiesProvider.$inject = [
 function createExternalFormGroup(element, translate, moddle, commandStack) {
   return {
     id: EXTERNAL_FORM_GROUP_ID,
-    label: translate('Web Form (External Form)'),
+    // A VNode, not a plain string: the panel renders `label` as TooltipWrapper children,
+    // and this is the only part of the group that stays visible while it is collapsed.
+    // ExternalFormSmtpLabel appends a warning marker when the tenant cannot send email,
+    // so the modeler sees the problem without having to expand the group first.
+    label: createElement(ExternalFormSmtpLabel, {
+      label: translate('Web Form (External Form)'),
+    }),
     entries: [
       {
         id: `extension_${EXTERNAL_FORM_URL_PROP}`,
@@ -62,6 +73,14 @@ function createExternalFormGroup(element, translate, moddle, commandStack) {
         description: translate(
           'When set, this user task uses an external form. Assignees are emailed a secure link to this URL. Clear the field to disable.'
         ),
+      },
+      {
+        // Warns when the tenant has no usable NATS_SMTP_* secrets, so the emailed link
+        // this field promises would never actually be delivered. Renders nothing when
+        // SMTP is configured, or when the status cannot be read.
+        id: 'extension_externalFormSmtpStatus',
+        element,
+        component: ExternalFormSmtpStatus,
       },
     ],
   };

--- a/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts
@@ -6,6 +6,12 @@ vi.mock(
   () => ({ SpiffExtensionTextInput: function SpiffExtensionTextInputStub() {} }),
 );
 
+// Stub so the test doesn't load the panel's bundled preact hooks or the HTTP service.
+vi.mock('./ExternalFormSmtpStatus', () => ({
+  ExternalFormSmtpStatus: function ExternalFormSmtpStatusStub() {},
+  ExternalFormSmtpLabel: function ExternalFormSmtpLabelStub() {},
+}));
+
 import ExternalFormPropertiesProvider, {
   EXTERNAL_FORM_GROUP_ID,
   EXTERNAL_FORM_URL_PROP,
@@ -53,9 +59,11 @@ describe('ExternalFormPropertiesProvider', () => {
     expect(groups).toHaveLength(1);
     const [group] = groups;
     expect(group.id).toBe(EXTERNAL_FORM_GROUP_ID);
-    expect(group.label).toBe('Web Form (External Form)');
+    // The label is a VNode, not a bare string: it must stay visible while the group is
+    // collapsed so ExternalFormSmtpLabel can mark an unconfigured tenant there.
+    expect(group.label.props.label).toBe('Web Form (External Form)');
 
-    expect(group.entries).toHaveLength(1);
+    expect(group.entries).toHaveLength(2);
     const [urlEntry] = group.entries;
     expect(urlEntry.name).toBe(EXTERNAL_FORM_URL_PROP);
     expect(urlEntry.name).toBe('externalFormUrl');
@@ -64,6 +72,22 @@ describe('ExternalFormPropertiesProvider', () => {
     expect(urlEntry.moddle).toBe(moddle);
     expect(urlEntry.commandStack).toBe(commandStack);
     expect(typeof urlEntry.component).toBe('function');
+  });
+
+  it('includes the SMTP configuration warning entry', () => {
+    // Without it, setting an external form URL silently promises an email that the
+    // notification worker cannot send when the tenant has no NATS_SMTP_* secrets.
+    const { provider } = instantiate();
+    const element = makeElement('bpmn:UserTask');
+
+    const [group] = provider.getGroups(element)([]);
+    const smtpEntry = group.entries.find(
+      (entry: any) => entry.id === 'extension_externalFormSmtpStatus',
+    );
+
+    expect(smtpEntry).toBeDefined();
+    expect(smtpEntry.element).toBe(element);
+    expect(typeof smtpEntry.component).toBe('function');
   });
 
   it('does not add the group to non-user-task elements', () => {

--- a/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.jsx
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { useEffect, useState } from '@bpmn-io/properties-panel/preact/hooks';
+import { getSmtpStatus } from '../../services/ExternalFormNotificationService';
+
+/**
+ * SMTP readiness for the External Form properties group.
+ *
+ * Setting an External form URL promises the assignee an email, but SMTP lives in tenant
+ * secrets configured somewhere else entirely — so without this the modeler gets no hint
+ * that the promise cannot be kept.
+ *
+ * Rendered by @bpmn-io/properties-panel's bundled preact, so hooks come from its subpath
+ * export (the same import upstream's SpiffExtensionTaskMetadata uses).
+ */
+
+/**
+ * Resolved SMTP status, or null while loading / on any failure.
+ *
+ * Failure deliberately yields null rather than an error state: the modeler must never
+ * break because a status call failed or the user lacks permission to read it.
+ *
+ * getSmtpStatus caches the in-flight promise per tenant, so the label marker and the
+ * detail entry calling this independently still produce a single request.
+ */
+function useSmtpStatus() {
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    try {
+      getSmtpStatus()
+        .then((result) => {
+          if (!cancelled) {
+            setStatus(result);
+          }
+        })
+        .catch(() => {});
+    } catch {
+      // Defensive: getSmtpStatus should return a promise, never throw synchronously.
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return status;
+}
+
+/**
+ * Marker rendered into the group *label*, which lives in the header and stays visible
+ * while the group is collapsed.
+ *
+ * The entries container is `display: none` until the group is expanded, and the panel
+ * gives a provider no way to light up the header's own edited/error dot (`isEdited` needs
+ * a DOM node that only exists once open; `errors` is a panel-level prop). The label is
+ * therefore the only always-visible surface available here.
+ */
+export function ExternalFormSmtpLabel({ label }) {
+  const status = useSmtpStatus();
+  const unconfigured = Boolean(status) && !status.configured;
+
+  if (!unconfigured) {
+    return label;
+  }
+
+  return (
+    <span data-testid="external-form-smtp-label">
+      {label}{' '}
+      <span
+        title="Email notifications are not configured for this tenant."
+        style={{ color: '#d97706', fontWeight: 'bold' }}
+      >
+        ⚠
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The detail shown inside the group once expanded: which tenant secrets are missing.
+ * Renders nothing when SMTP is usable, still loading, or unreadable.
+ */
+export function ExternalFormSmtpStatus() {
+  const status = useSmtpStatus();
+
+  if (!status || status.configured) {
+    return null;
+  }
+
+  const missing = status.missing_required_keys || [];
+
+  return (
+    <div
+      className="bio-properties-panel-entry"
+      data-testid="external-form-smtp-warning"
+      style={{ padding: '8px 0' }}
+    >
+      <div
+        style={{
+          borderLeft: '3px solid #d97706',
+          paddingLeft: '8px',
+          fontSize: '12px',
+          lineHeight: 1.5,
+        }}
+      >
+        <strong>Email notifications are not configured.</strong> Assignees will
+        not receive the secure link until these tenant secrets are set under
+        Configuration &gt; Secrets:
+        <ul style={{ margin: '4px 0 0 0', paddingLeft: '16px' }}>
+          {missing.map((key) => (
+            <li key={key}>
+              <code>{key}</code>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default ExternalFormSmtpStatus;

--- a/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.test.tsx
+++ b/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const getSmtpStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/ExternalFormNotificationService', () => ({
+  getSmtpStatus,
+}));
+
+// The components import hooks from the properties panel's bundled preact. Under Vitest
+// the app renders with real React (vite.config disables the preact alias), so map that
+// subpath onto React's equivalents.
+vi.mock('@bpmn-io/properties-panel/preact/hooks', async () => {
+  const react = await import('react');
+  return { useEffect: react.useEffect, useState: react.useState };
+});
+
+import {
+  ExternalFormSmtpLabel,
+  ExternalFormSmtpStatus,
+} from './ExternalFormSmtpStatus';
+
+const CONFIGURED = {
+  configured: true,
+  required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+  optional_keys: [],
+  missing_required_keys: [],
+  unreadable_keys: [],
+  reason: null,
+  configured_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+};
+
+const UNCONFIGURED = {
+  ...CONFIGURED,
+  configured: false,
+  missing_required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+  configured_keys: [],
+  reason: 'SMTP is not configured for this tenant.',
+};
+
+beforeEach(() => {
+  getSmtpStatus.mockReset();
+});
+
+describe('ExternalFormSmtpLabel', () => {
+  it('marks the group label when the tenant cannot send email', async () => {
+    // The label is the only part of the group visible while it is collapsed, so this
+    // marker is what actually surfaces the problem to a modeler.
+    getSmtpStatus.mockResolvedValue(UNCONFIGURED);
+
+    render(<ExternalFormSmtpLabel label="Web Form (External Form)" />);
+
+    const marked = await screen.findByTestId('external-form-smtp-label');
+    expect(marked).toHaveTextContent('Web Form (External Form)');
+    expect(marked).toHaveTextContent('⚠');
+  });
+
+  it('leaves the label untouched when SMTP is configured', async () => {
+    getSmtpStatus.mockResolvedValue(CONFIGURED);
+
+    render(<ExternalFormSmtpLabel label="Web Form (External Form)" />);
+
+    await waitFor(() => expect(getSmtpStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('external-form-smtp-label')).toBeNull();
+    expect(screen.getByText('Web Form (External Form)')).toBeInTheDocument();
+  });
+
+  it('leaves the label untouched when the status cannot be read', async () => {
+    getSmtpStatus.mockRejectedValue(new Error('403'));
+
+    render(<ExternalFormSmtpLabel label="Web Form (External Form)" />);
+
+    await waitFor(() => expect(getSmtpStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('external-form-smtp-label')).toBeNull();
+    expect(screen.getByText('Web Form (External Form)')).toBeInTheDocument();
+  });
+});
+
+describe('ExternalFormSmtpStatus', () => {
+  it('lists the missing secrets', async () => {
+    getSmtpStatus.mockResolvedValue(UNCONFIGURED);
+
+    render(<ExternalFormSmtpStatus />);
+
+    const warning = await screen.findByTestId('external-form-smtp-warning');
+    expect(warning).toHaveTextContent('NATS_SMTP_HOST');
+    expect(warning).toHaveTextContent('NATS_SMTP_FROM_EMAIL');
+    expect(warning).toHaveTextContent('Configuration > Secrets');
+  });
+
+  it('renders nothing when SMTP is configured', async () => {
+    getSmtpStatus.mockResolvedValue(CONFIGURED);
+
+    render(<ExternalFormSmtpStatus />);
+
+    await waitFor(() => expect(getSmtpStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('external-form-smtp-warning')).toBeNull();
+  });
+
+  it('renders nothing when the status call fails', async () => {
+    // A failed or forbidden status call must never break the modeler.
+    getSmtpStatus.mockRejectedValue(new Error('403'));
+
+    render(<ExternalFormSmtpStatus />);
+
+    await waitFor(() => expect(getSmtpStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('external-form-smtp-warning')).toBeNull();
+  });
+
+  it('renders nothing when getSmtpStatus throws synchronously', async () => {
+    getSmtpStatus.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => render(<ExternalFormSmtpStatus />)).not.toThrow();
+    expect(screen.queryByTestId('external-form-smtp-warning')).toBeNull();
+  });
+
+  it('tolerates a payload with no missing-key list', async () => {
+    getSmtpStatus.mockResolvedValue({
+      ...UNCONFIGURED,
+      missing_required_keys: undefined,
+    });
+
+    render(<ExternalFormSmtpStatus />);
+
+    const warning = await screen.findByTestId('external-form-smtp-warning');
+    expect(warning).toBeInTheDocument();
+  });
+});

--- a/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx
+++ b/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx
@@ -18,6 +18,9 @@ export const useM8flowUriListForPermissions = () => {
       // tenant; /varz and /jsz do not), so this is what gates the page and nav item rather
       // than a super-admin flag.
       m8flowNatsEventsPath: "/m8flow/nats/events",
+      m8flowExternalFormNotificationsPath: "/m8flow/external-form-notifications",
+      m8flowExternalFormSmtpStatusPath:
+        "/m8flow/external-form-notifications/smtp-status",
     };
   }, [spiffTargetUris]);
 

--- a/m8flow-frontend/src/locales/en_us/translation.json
+++ b/m8flow-frontend/src/locales/en_us/translation.json
@@ -459,5 +459,7 @@
   "continuing_into_tenant": "Continuing into {{tenant}}...",
   "select_a_tenant": "Select a Tenant",
   "multi_tenant_choose_description": "Your account has access to more than one tenant. Choose the tenant you want to enter for this session.",
-  "owner": "Owner"
+  "owner": "Owner",
+  "external_form_smtp_missing_hint": "External form notification emails cannot be sent: this tenant is missing the following secrets. Add them here to start delivering secure links.",
+  "external_form_smtp_configured_hint": "External form notification emails are configured. They use these secrets:"
 }

--- a/m8flow-frontend/src/services/ExternalFormNotificationService.test.ts
+++ b/m8flow-frontend/src/services/ExternalFormNotificationService.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const makeCallToBackend = vi.hoisted(() => vi.fn());
+
+vi.mock('@spiffworkflow-frontend/services/HttpService', () => ({
+  default: { makeCallToBackend },
+}));
+
+import {
+  clearSmtpStatusCache,
+  getNotifications,
+  getSmtpStatus,
+  resendNotification,
+} from './ExternalFormNotificationService';
+
+const CONFIGURED = {
+  configured: true,
+  required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+  optional_keys: ['NATS_SMTP_PORT'],
+  missing_required_keys: [],
+  unreadable_keys: [],
+  reason: null,
+  configured_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+};
+
+function respondWith(payload: any) {
+  makeCallToBackend.mockImplementation((opts: any) => {
+    opts.successCallback(payload);
+  });
+}
+
+function failWith(error: any) {
+  makeCallToBackend.mockImplementation((opts: any) => {
+    opts.failureCallback(error);
+  });
+}
+
+beforeEach(() => {
+  makeCallToBackend.mockReset();
+  clearSmtpStatusCache();
+});
+
+describe('getSmtpStatus', () => {
+  it('requests the status path without a /v1.0 prefix duplication', async () => {
+    respondWith(CONFIGURED);
+
+    await getSmtpStatus();
+
+    expect(makeCallToBackend).toHaveBeenCalledTimes(1);
+    expect(makeCallToBackend.mock.calls[0][0].path).toBe(
+      '/v1.0/m8flow/external-form-notifications/smtp-status',
+    );
+    expect(makeCallToBackend.mock.calls[0][0].httpMethod).toBe('GET');
+  });
+
+  it('passes the tenant id through for super admins', async () => {
+    respondWith(CONFIGURED);
+
+    await getSmtpStatus('tenant-1');
+
+    expect(makeCallToBackend.mock.calls[0][0].path).toBe(
+      '/v1.0/m8flow/external-form-notifications/smtp-status?tenantId=tenant-1',
+    );
+  });
+
+  it('shares one in-flight request between concurrent callers', async () => {
+    respondWith(CONFIGURED);
+
+    const [a, b] = await Promise.all([getSmtpStatus(), getSmtpStatus()]);
+
+    expect(makeCallToBackend).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it('caches per tenant so switching tenants re-fetches', async () => {
+    respondWith(CONFIGURED);
+
+    await getSmtpStatus('tenant-1');
+    await getSmtpStatus('tenant-2');
+    await getSmtpStatus('tenant-1');
+
+    // One call per distinct tenant; the repeat is served from the cache. A single
+    // unkeyed entry would report tenant-1's verdict for tenant-2.
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+    const paths = makeCallToBackend.mock.calls.map((call: any) => call[0].path);
+    expect(paths[0]).toContain('tenantId=tenant-1');
+    expect(paths[1]).toContain('tenantId=tenant-2');
+  });
+
+  it('does not cache a failure, so a later retry still reaches the backend', async () => {
+    failWith(new Error('403'));
+    await expect(getSmtpStatus()).rejects.toBeTruthy();
+
+    respondWith(CONFIGURED);
+    await expect(getSmtpStatus()).resolves.toEqual(CONFIGURED);
+
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearSmtpStatusCache forces a refetch for one tenant', async () => {
+    respondWith(CONFIGURED);
+    await getSmtpStatus('tenant-1');
+
+    clearSmtpStatusCache('tenant-1');
+    await getSmtpStatus('tenant-1');
+
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearSmtpStatusCache with no arguments clears all cached tenants', async () => {
+    respondWith(CONFIGURED);
+    await getSmtpStatus('tenant-1');
+    await getSmtpStatus('tenant-2');
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+
+    clearSmtpStatusCache();
+    await getSmtpStatus('tenant-1');
+    await getSmtpStatus('tenant-2');
+
+    expect(makeCallToBackend).toHaveBeenCalledTimes(4);
+  });
+
+  it('getSmtpStatus with force: true bypasses and replaces the cached verdict', async () => {
+    respondWith(CONFIGURED);
+    await getSmtpStatus('tenant-1');
+    expect(makeCallToBackend).toHaveBeenCalledTimes(1);
+
+    await getSmtpStatus('tenant-1', { force: true });
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+
+    // Subsequent regular call uses the new cached entry
+    await getSmtpStatus('tenant-1');
+    expect(makeCallToBackend).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the missing key names when the tenant is unconfigured', async () => {
+    respondWith({
+      ...CONFIGURED,
+      configured: false,
+      missing_required_keys: ['NATS_SMTP_HOST'],
+      configured_keys: ['NATS_SMTP_FROM_EMAIL'],
+      reason: 'SMTP is not configured for this tenant.',
+    });
+
+    const status = await getSmtpStatus();
+
+    expect(status.configured).toBe(false);
+    expect(status.missing_required_keys).toEqual(['NATS_SMTP_HOST']);
+  });
+});
+
+describe('getNotifications', () => {
+  it('requests the bare collection path with no query when unfiltered', async () => {
+    respondWith({ results: [], pagination: { count: 0, total: 0, pages: 0 } });
+
+    await getNotifications();
+
+    expect(makeCallToBackend.mock.calls[0][0].path).toBe(
+      '/v1.0/m8flow/external-form-notifications',
+    );
+  });
+
+  it('serializes every supported filter', async () => {
+    respondWith({ results: [], pagination: { count: 0, total: 0, pages: 0 } });
+
+    await getNotifications({
+      processInstanceId: 42,
+      status: 'smtp_unconfigured',
+      page: 2,
+      perPage: 25,
+      tenantId: 'tenant-1',
+    });
+
+    const { path } = makeCallToBackend.mock.calls[0][0];
+    expect(path).toContain('process_instance_id=42');
+    expect(path).toContain('status=smtp_unconfigured');
+    expect(path).toContain('page=2');
+    expect(path).toContain('per_page=25');
+    expect(path).toContain('tenantId=tenant-1');
+  });
+
+  it('returns the parsed page', async () => {
+    const page = {
+      results: [{ id: 1, status: 'smtp_unconfigured', last_error: 'no smtp' }],
+      pagination: { count: 1, total: 1, pages: 1 },
+    };
+    respondWith(page);
+
+    await expect(getNotifications()).resolves.toEqual(page);
+  });
+});
+
+describe('resendNotification', () => {
+  it('POSTs to the resend path', async () => {
+    respondWith({ ok: true, id: 7, status: 'pending', message: 'queued' });
+
+    await resendNotification(7);
+
+    const call = makeCallToBackend.mock.calls[0][0];
+    expect(call.path).toBe(
+      '/v1.0/m8flow/external-form-notifications/7/resend',
+    );
+    expect(call.httpMethod).toBe('POST');
+  });
+
+  it('includes the tenant id when given', async () => {
+    respondWith({ ok: true, id: 7, status: 'pending', message: 'queued' });
+
+    await resendNotification(7, 'tenant-1');
+
+    expect(makeCallToBackend.mock.calls[0][0].path).toBe(
+      '/v1.0/m8flow/external-form-notifications/7/resend?tenantId=tenant-1',
+    );
+  });
+
+  it('rejects when the row cannot be resent', async () => {
+    failWith({ error_code: 'external_form_request_not_resendable' });
+
+    await expect(resendNotification(7)).rejects.toEqual({
+      error_code: 'external_form_request_not_resendable',
+    });
+  });
+});

--- a/m8flow-frontend/src/services/ExternalFormNotificationService.ts
+++ b/m8flow-frontend/src/services/ExternalFormNotificationService.ts
@@ -1,0 +1,171 @@
+import HttpService from '@spiffworkflow-frontend/services/HttpService';
+
+const BASE_PATH = '/v1.0/m8flow/external-form-notifications';
+
+export const SMTP_STATUS_PATH = '/m8flow/external-form-notifications/smtp-status';
+export const NOTIFICATIONS_PATH = '/m8flow/external-form-notifications';
+
+export interface SmtpStatus {
+  /** True when every required key is set to a usable value. */
+  configured: boolean;
+  /** Keys without which no external form email can be sent. */
+  required_keys: string[];
+  optional_keys: string[];
+  /** Required keys that are not usable — absent, blank, or undecryptable. */
+  missing_required_keys: string[];
+  /**
+   * Subset of the above whose secret exists but does not resolve (blank, or the backend
+   * encryption key changed). Re-entering the key is not the fix for these.
+   */
+  unreadable_keys?: string[];
+  /** Backend explanation of why sending is blocked; null when configured. */
+  reason?: string | null;
+  /**
+   * Keys with a usable (decryptable, non-blank) value. Names only — values are never
+   * returned by the backend.
+   */
+  configured_keys: string[];
+}
+
+export interface ExternalFormNotification {
+  id: number;
+  process_instance_id: number;
+  task_guid: string;
+  email: string;
+  /**
+   * pending | notified | submitted | completed | failed | expired | superseded |
+   * smtp_unconfigured (parked: the tenant has no usable SMTP configuration, so the
+   * worker has stopped retrying it).
+   */
+  status: string;
+  attempts: number;
+  last_error: string | null;
+  created_at_in_seconds: number;
+  updated_at_in_seconds: number;
+  notified_at_in_seconds: number | null;
+  expires_at_in_seconds: number | null;
+  /** Present for super-admin requests only. */
+  tenantId?: string;
+  tenantName?: string | null;
+}
+
+export interface ExternalFormNotificationPage {
+  results: ExternalFormNotification[];
+  pagination: { count: number; total: number; pages: number };
+}
+
+const callBackend = <T,>(opts: {
+  path: string;
+  httpMethod?: string;
+  postBody?: any;
+}): Promise<T> =>
+  new Promise((resolve, reject) => {
+    HttpService.makeCallToBackend({
+      path: opts.path,
+      httpMethod: opts.httpMethod ?? 'GET',
+      postBody: opts.postBody,
+      successCallback: resolve as (result: any) => void,
+      failureCallback: reject,
+    });
+  });
+
+/**
+ * In-flight/settled SMTP status, shared across callers, keyed by tenant.
+ *
+ * Both the Secrets page banner and the BPMN modeler's External Form group ask for this,
+ * potentially at the same time; caching the promise means one request answers both and a
+ * re-mount does not refetch.
+ *
+ * The key matters: a super admin can switch the tenant they are viewing, and the answer is
+ * per-tenant. A single unkeyed entry would keep showing the first tenant's verdict for the
+ * rest of the session.
+ */
+const smtpStatusByTenant = new Map<string, Promise<SmtpStatus>>();
+
+const cacheKeyFor = (tenantId?: string | null): string => tenantId || '__active__';
+
+export interface GetSmtpStatusOptions {
+  force?: boolean;
+}
+
+export const getSmtpStatus = (
+  tenantId?: string | null,
+  options?: GetSmtpStatusOptions | boolean,
+): Promise<SmtpStatus> => {
+  const force = typeof options === 'boolean' ? options : Boolean(options?.force);
+  const key = cacheKeyFor(tenantId);
+  if (force) {
+    smtpStatusByTenant.delete(key);
+  }
+  const cached = smtpStatusByTenant.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const path = tenantId
+    ? `${BASE_PATH}/smtp-status?tenantId=${encodeURIComponent(tenantId)}`
+    : `${BASE_PATH}/smtp-status`;
+
+  // Drop a rejected lookup from the cache so a transient failure (or a 400 a super admin
+  // gets before choosing a tenant) does not stick for the rest of the session.
+  const pending = callBackend<SmtpStatus>({ path }).catch((error) => {
+    smtpStatusByTenant.delete(key);
+    throw error;
+  });
+  smtpStatusByTenant.set(key, pending);
+  return pending;
+};
+
+/** Forget a cached verdict, e.g. after the admin saves a secret. */
+export const clearSmtpStatusCache = (tenantId?: string | null): void => {
+  if (tenantId === undefined) {
+    smtpStatusByTenant.clear();
+    return;
+  }
+  smtpStatusByTenant.delete(cacheKeyFor(tenantId));
+};
+
+export const getNotifications = (opts?: {
+  processInstanceId?: number;
+  status?: string;
+  page?: number;
+  perPage?: number;
+  tenantId?: string | null;
+}): Promise<ExternalFormNotificationPage> => {
+  const query = new URLSearchParams();
+  if (opts?.processInstanceId !== undefined) {
+    query.set('process_instance_id', String(opts.processInstanceId));
+  }
+  if (opts?.status) query.set('status', opts.status);
+  if (opts?.page !== undefined) query.set('page', String(opts.page));
+  if (opts?.perPage !== undefined) query.set('per_page', String(opts.perPage));
+  if (opts?.tenantId) query.set('tenantId', opts.tenantId);
+
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return callBackend<ExternalFormNotificationPage>({
+    path: `${BASE_PATH}${suffix}`,
+  });
+};
+
+/**
+ * Requeue one notification. The worker delivers it on its next sweep, so this is not
+ * instantaneous.
+ */
+export const resendNotification = (
+  requestId: number,
+  tenantId?: string | null,
+): Promise<{ ok: boolean; id: number; status: string; message: string }> => {
+  const suffix = tenantId ? `?tenantId=${encodeURIComponent(tenantId)}` : '';
+  return callBackend({
+    path: `${BASE_PATH}/${requestId}/resend${suffix}`,
+    httpMethod: 'POST',
+    postBody: {},
+  });
+};
+
+export default {
+  getSmtpStatus,
+  clearSmtpStatusCache,
+  getNotifications,
+  resendNotification,
+};

--- a/m8flow-frontend/src/views/ConnectorConfigure.test.tsx
+++ b/m8flow-frontend/src/views/ConnectorConfigure.test.tsx
@@ -62,6 +62,10 @@ vi.mock('react-i18next', () => {
   const t = (key: string, opts?: { name?: string }) =>
     opts?.name ? `${key}:${opts.name}` : key;
   return {
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => undefined,
+    },
     useTranslation: () => ({ t }),
   };
 });

--- a/m8flow-frontend/src/views/ConnectorConfigure.tsx
+++ b/m8flow-frontend/src/views/ConnectorConfigure.tsx
@@ -33,6 +33,7 @@ import { PermissionsToCheck } from '@spiffworkflow-frontend/interfaces';
 import { usePermissionFetcher } from '@spiffworkflow-frontend/hooks/PermissionService';
 import { ConnectorNameAvatar } from '../utils/connectorCardDisplay';
 import { Notification } from '../components/Notification';
+import { clearSmtpStatusCache } from '../services/ExternalFormNotificationService';
 import {
   type ConnectorConfigField,
   type ConnectorGroup,
@@ -311,6 +312,7 @@ export default function ConnectorConfigure() {
     setSaveError(null);
     Promise.all(tasks)
       .then(() => {
+        clearSmtpStatusCache();
         // Everything entered is now persisted; reflect that in the form state.
         setFieldStates((prev) => {
           const next = { ...prev };

--- a/m8flow-frontend/src/views/SecretList.test.tsx
+++ b/m8flow-frontend/src/views/SecretList.test.tsx
@@ -68,9 +68,35 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('../services/ExternalFormNotificationService', () => ({
+  getSmtpStatus: vi.fn(),
+  clearSmtpStatusCache: vi.fn(),
+}));
+
 import UserService from '../services/UserService';
 import { useGlobalTenant } from '../contexts/GlobalTenantContext';
 import HttpService from '../services/HttpService';
+import {
+  getSmtpStatus,
+  clearSmtpStatusCache,
+} from '../services/ExternalFormNotificationService';
+
+const SMTP_CONFIGURED = {
+  configured: true,
+  required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+  optional_keys: [],
+  missing_required_keys: [],
+  unreadable_keys: [],
+  reason: null,
+  configured_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+};
+
+function stubSmtpStatus(overrides: Record<string, unknown> = {}) {
+  vi.mocked(getSmtpStatus).mockResolvedValue({
+    ...SMTP_CONFIGURED,
+    ...overrides,
+  } as any);
+}
 
 function stubSecretsList() {
   vi.mocked(HttpService.makeCallToBackend).mockImplementation((opts: any) => {
@@ -101,9 +127,10 @@ describe('SecretList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     stubSecretsList();
+    stubSmtpStatus();
   });
 
-  it('sends tenantId and shows the tenant column for super-admin', () => {
+  it('sends tenantId and shows the tenant column for super-admin', async () => {
     vi.mocked(UserService.isSuperAdmin).mockReturnValue(true);
     vi.mocked(useGlobalTenant).mockReturnValue({
       selectedTenantId: 'tenant-a',
@@ -118,9 +145,11 @@ describe('SecretList', () => {
     expect(screen.getByTestId('secret-list-tenant-cell')).toHaveTextContent(
       'Acme',
     );
+    // Let the async SMTP banner settle inside the test rather than after it.
+    await screen.findByTestId('external-form-smtp-configured');
   });
 
-  it('omits tenantId and the tenant column for non-super-admin', () => {
+  it('omits tenantId and the tenant column for non-super-admin', async () => {
     vi.mocked(UserService.isSuperAdmin).mockReturnValue(false);
     vi.mocked(useGlobalTenant).mockReturnValue({
       selectedTenantId: 'tenant-a',
@@ -133,5 +162,109 @@ describe('SecretList', () => {
       }),
     );
     expect(screen.queryByTestId('secret-list-tenant-cell')).toBeNull();
+    await screen.findByTestId('external-form-smtp-configured');
+  });
+});
+
+describe('SecretList external form email banner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSecretsList();
+    vi.mocked(UserService.isSuperAdmin).mockReturnValue(false);
+    vi.mocked(useGlobalTenant).mockReturnValue({
+      selectedTenantId: '',
+      setSelectedTenantId: vi.fn(),
+    });
+  });
+
+  it('names the missing NATS_SMTP_* secrets when the tenant is unconfigured', async () => {
+    // Nothing else on this page names these keys, so without the banner a tenant admin
+    // has no way to discover why external form emails silently never arrive.
+    stubSmtpStatus({
+      configured: false,
+      missing_required_keys: ['NATS_SMTP_HOST', 'NATS_SMTP_FROM_EMAIL'],
+      reason: 'SMTP is not configured for this tenant.',
+    });
+
+    renderList();
+
+    const banner = await screen.findByTestId(
+      'external-form-smtp-not-configured',
+    );
+    expect(banner).toHaveTextContent('external_form_smtp_missing_hint');
+    expect(banner).toHaveTextContent('NATS_SMTP_HOST');
+    expect(banner).toHaveTextContent('NATS_SMTP_FROM_EMAIL');
+  });
+
+  it('shows the backend reason when a secret is unreadable rather than missing', async () => {
+    // Re-entering the key is not the fix here, so the generic "these are missing"
+    // headline would send the admin down the wrong path.
+    stubSmtpStatus({
+      configured: false,
+      missing_required_keys: ['NATS_SMTP_FROM_EMAIL'],
+      unreadable_keys: ['NATS_SMTP_FROM_EMAIL'],
+      reason:
+        'SMTP secrets exist but could not be read (blank value, or the backend encryption key changed): NATS_SMTP_FROM_EMAIL',
+    });
+
+    renderList();
+
+    const banner = await screen.findByTestId(
+      'external-form-smtp-not-configured',
+    );
+    expect(banner).toHaveTextContent('encryption key changed');
+    expect(banner).not.toHaveTextContent('external_form_smtp_missing_hint');
+  });
+
+  it('reports the configured case without warning', async () => {
+    stubSmtpStatus();
+
+    renderList();
+
+    expect(
+      await screen.findByTestId('external-form-smtp-configured'),
+    ).toHaveTextContent('external_form_smtp_configured_hint');
+    expect(
+      screen.queryByTestId('external-form-smtp-not-configured'),
+    ).toBeNull();
+  });
+
+  it('hides the banner when the status cannot be read', async () => {
+    // Covers both a 403 for a user without the permission and the 400 a super admin
+    // gets before choosing a tenant. Neither may break the Secrets page.
+    vi.mocked(getSmtpStatus).mockRejectedValue(new Error('403'));
+
+    renderList();
+
+    expect(await screen.findByText('secrets')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('external-form-smtp-not-configured'),
+    ).toBeNull();
+    expect(screen.queryByTestId('external-form-smtp-configured')).toBeNull();
+  });
+
+  it('asks for the selected tenant status as a super admin', async () => {
+    vi.mocked(UserService.isSuperAdmin).mockReturnValue(true);
+    vi.mocked(useGlobalTenant).mockReturnValue({
+      selectedTenantId: 'tenant-a',
+      setSelectedTenantId: vi.fn(),
+    });
+    stubSmtpStatus();
+
+    renderList();
+
+    await screen.findByTestId('external-form-smtp-configured');
+    expect(clearSmtpStatusCache).toHaveBeenCalledWith('tenant-a');
+    expect(getSmtpStatus).toHaveBeenCalledWith('tenant-a', { force: true });
+  });
+
+  it('does not pass a tenant id for a normal tenant user', async () => {
+    stubSmtpStatus();
+
+    renderList();
+
+    await screen.findByTestId('external-form-smtp-configured');
+    expect(clearSmtpStatusCache).toHaveBeenCalledWith(null);
+    expect(getSmtpStatus).toHaveBeenCalledWith(null, { force: true });
   });
 });

--- a/m8flow-frontend/src/views/SecretList.tsx
+++ b/m8flow-frontend/src/views/SecretList.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import {
+  Alert,
   Box,
   Button,
   Dialog,
@@ -31,6 +32,11 @@ import { useUriListForPermissions } from '../hooks/UriListForPermissions';
 import { useGlobalTenant } from '../contexts/GlobalTenantContext';
 import HttpService from '../services/HttpService';
 import UserService from '../services/UserService';
+import {
+  clearSmtpStatusCache,
+  getSmtpStatus,
+  type SmtpStatus,
+} from '../services/ExternalFormNotificationService';
 import type { PermissionsToCheck } from '../interfaces';
 
 type SecretRow = {
@@ -66,6 +72,9 @@ export default function SecretList() {
   const [rows, setRows] = useState<SecretRow[]>([]);
   const [pageMeta, setPageMeta] = useState<any>(null);
   const [pendingDelete, setPendingDelete] = useState<SecretRow | null>(null);
+  // Null until the SMTP status resolves; stays null if the call fails or the user lacks
+  // permission, in which case no banner is shown at all.
+  const [smtpStatus, setSmtpStatus] = useState<SmtpStatus | null>(null);
 
   const { ability, permissionsLoaded } = usePermissionFetcher({
     [targetUris.authenticationListPath]: ['GET'],
@@ -105,11 +114,38 @@ export default function SecretList() {
     load,
   ]);
 
+  // External form notification emails silently do nothing until the tenant's NATS_SMTP_*
+  // secrets exist, and nothing else on this page names those keys. Surface the gap here,
+  // where the fix lives. A failure leaves the banner hidden — that covers a 403 for a user
+  // who cannot read the status, and the 400 a super admin gets before choosing a tenant.
+  //
+  // Depends on selectedTenantId: the answer is per-tenant, and the table below already
+  // re-fetches on switch, so the banner must not keep the previous tenant's verdict.
+  // Force a fresh fetch each time SecretList mounts or the tenant changes so that newly
+  // added or updated SMTP secrets are reflected immediately without needing a browser reload.
+  useEffect(() => {
+    let cancelled = false;
+    const tenantId = sa ? selectedTenantId : null;
+    setSmtpStatus(null);
+    clearSmtpStatusCache(tenantId);
+    getSmtpStatus(tenantId, { force: true })
+      .then((result) => {
+        if (!cancelled) setSmtpStatus(result);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [sa, selectedTenantId]);
+
   const confirmDelete = (key: string) => {
     HttpService.makeCallToBackend({
       path: `/secrets/${key}`,
       httpMethod: 'DELETE',
-      successCallback: () => window.location.reload(),
+      successCallback: () => {
+        clearSmtpStatusCache(sa ? selectedTenantId : null);
+        window.location.reload();
+      },
     });
   };
 
@@ -118,6 +154,44 @@ export default function SecretList() {
   }
 
   const { page, perPage } = getPageInfoFromSearchParams(searchParams);
+
+  const externalFormEmailBanner = () => {
+    if (!smtpStatus) return null;
+    const keys = smtpStatus.configured
+      ? smtpStatus.required_keys
+      : smtpStatus.missing_required_keys;
+    // "These keys are missing" is wrong when the secret exists but cannot be decrypted —
+    // adding it again would not help. Show the backend's specific reason instead.
+    const unreadable = smtpStatus.unreadable_keys ?? [];
+    const headline =
+      unreadable.length > 0 && smtpStatus.reason
+        ? smtpStatus.reason
+        : smtpStatus.configured
+          ? t('external_form_smtp_configured_hint')
+          : t('external_form_smtp_missing_hint');
+    return (
+      <Alert
+        severity={smtpStatus.configured ? 'info' : 'warning'}
+        sx={{ mb: 2 }}
+        data-testid={
+          smtpStatus.configured
+            ? 'external-form-smtp-configured'
+            : 'external-form-smtp-not-configured'
+        }
+      >
+        {headline}{' '}
+        {keys.map((key) => (
+          <Box
+            key={key}
+            component="code"
+            sx={{ fontFamily: 'monospace', mr: 1, whiteSpace: 'nowrap' }}
+          >
+            {key}
+          </Box>
+        ))}
+      </Alert>
+    );
+  };
 
   const table = (
     <TableContainer component={Paper}>
@@ -181,6 +255,8 @@ export default function SecretList() {
           </Button>
         </Can>
       </Box>
+
+      {externalFormEmailBanner()}
 
       {rows.length > 0 ? (
         <PaginationForTable

--- a/m8flow-frontend/src/views/SecretShow.test.tsx
+++ b/m8flow-frontend/src/views/SecretShow.test.tsx
@@ -41,6 +41,10 @@ vi.mock('../components/Notification', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => undefined,
+  },
   useTranslation: () => ({
     t: (key: string) => key,
   }),

--- a/m8flow-frontend/src/views/SecretShow.tsx
+++ b/m8flow-frontend/src/views/SecretShow.tsx
@@ -12,6 +12,7 @@ import { Notification } from '../components/Notification';
 import { usePermissionFetcher } from '../hooks/PermissionService';
 import { useUriListForPermissions } from '../hooks/UriListForPermissions';
 import HttpService from '../services/HttpService';
+import { clearSmtpStatusCache } from '../services/ExternalFormNotificationService';
 import type { PermissionsToCheck, Secret } from '../interfaces';
 
 const HOME = '/configuration/secrets';
@@ -65,7 +66,10 @@ export default function SecretShow() {
               HttpService.makeCallToBackend({
                 path: `/secrets/${entry.key}`,
                 httpMethod: 'DELETE',
-                successCallback: () => go(HOME),
+                successCallback: () => {
+                  clearSmtpStatusCache();
+                  go(HOME);
+                },
               })
             }
           />
@@ -106,7 +110,10 @@ export default function SecretShow() {
                   path: `/secrets/${entry.key}`,
                   httpMethod: 'PUT',
                   postBody: { value: entry.value },
-                  successCallback: () => setFlash(true),
+                  successCallback: () => {
+                    clearSmtpStatusCache();
+                    setFlash(true);
+                  },
                 })
               }
             >

--- a/m8flow-nats-consumer/notification_worker.py
+++ b/m8flow-nats-consumer/notification_worker.py
@@ -12,6 +12,7 @@ always ACKed — failures are recorded on the row and retried by the sweep inste
 of through NATS redelivery.
 """
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -81,13 +82,68 @@ def _notify_one(tenant_id: str, reference_id: str) -> str:
             reset_context_tenant_id(token)
 
 
+def _in_tenant_context(tenant_id: str, work):
+    """Run `work()` inside an app context with `tenant_id` active, rolling back on error.
+
+    Same contract as _notify_one but for whole-tenant operations, so a tenant's SMTP
+    secrets are resolved once per sweep instead of once per request."""
+    from spiffworkflow_backend.models.db import db
+    from m8flow_backend.tenancy import set_context_tenant_id, reset_context_tenant_id
+
+    with flask_app.app_context():
+        token = set_context_tenant_id(tenant_id)
+        try:
+            return work()
+        except Exception:
+            db.session.rollback()
+            raise
+        finally:
+            reset_context_tenant_id(token)
+
+
+def _revive_reconfigured_tenants() -> None:
+    """Bring parked requests back once a tenant has configured its SMTP secrets.
+
+    Requests parked as smtp_unconfigured are invisible to sweep_candidates by design, so
+    without this pass they would stay stuck even after an admin fixes the configuration."""
+    from m8flow_backend.services.external_form_notification_service import ExternalFormNotificationService
+
+    with flask_app.app_context():
+        tenant_ids = ExternalFormNotificationService.tenants_with_parked_requests()
+
+    for tenant_id in tenant_ids:
+        try:
+
+            def revive_if_configured() -> int:
+                if not ExternalFormNotificationService.smtp_readiness()["ok"]:
+                    return 0
+                # UPDATEs bypass the SELECT tenant listener — pin tenant_id explicitly.
+                return ExternalFormNotificationService.revive_smtp_unconfigured(tenant_id=tenant_id)
+
+            revived = _in_tenant_context(tenant_id, revive_if_configured)
+            if revived:
+                logger.info(
+                    "Sweep revived %s parked request(s) for tenant=%s now that SMTP is configured.",
+                    revived,
+                    tenant_id,
+                )
+        except Exception:
+            logger.exception("Sweep revive check failed for tenant=%s", tenant_id)
+
+
 def _run_sweep() -> None:
     """One sweep pass: find requests still owed an email and send them.
 
     sweep_candidates runs cross-tenant (the tracking table is not tenant-row-locked);
     each send then runs under the owning row's tenant context. The atomic claim makes
-    racing the event fast-path harmless."""
+    racing the event fast-path harmless.
+
+    Candidates are grouped by tenant so SMTP configuration is checked once per tenant.
+    An unconfigured tenant parks all of its candidates in one statement and logs once,
+    instead of decrypting secrets and warning per row on every interval forever."""
     from m8flow_backend.services.external_form_notification_service import ExternalFormNotificationService
+
+    _revive_reconfigured_tenants()
 
     with flask_app.app_context():
         candidates = ExternalFormNotificationService.sweep_candidates()
@@ -95,13 +151,48 @@ def _run_sweep() -> None:
     if not candidates:
         return
 
-    logger.info("Sweep found %s request(s) owed an email.", len(candidates))
-    for _request_id, reference_id, tenant_id in candidates:
+    by_tenant: dict[str, list[tuple[int, str]]] = {}
+    for request_id, reference_id, tenant_id in candidates:
+        by_tenant.setdefault(tenant_id, []).append((request_id, reference_id))
+
+    logger.info("Sweep found %s request(s) owed an email across %s tenant(s).", len(candidates), len(by_tenant))
+    for tenant_id, rows in by_tenant.items():
         try:
-            result = _notify_one(tenant_id, reference_id)
-            logger.info("Sweep notify reference=%s…: %s", reference_id[:8], result)
+            readiness = _in_tenant_context(tenant_id, ExternalFormNotificationService.smtp_readiness)
         except Exception:
-            logger.exception("Sweep notify failed for reference=%s… (tenant=%s)", reference_id[:8], tenant_id)
+            logger.exception("Sweep could not read SMTP configuration for tenant=%s", tenant_id)
+            continue
+
+        if not readiness["ok"]:
+            try:
+                request_ids = [request_id for request_id, _ in rows]
+                parked = _in_tenant_context(
+                    tenant_id,
+                    functools.partial(
+                        ExternalFormNotificationService.mark_smtp_unconfigured,
+                        request_ids,
+                        readiness["reason"],
+                    ),
+                )
+            except Exception:
+                logger.exception("Sweep could not park requests for tenant=%s", tenant_id)
+                continue
+            logger.error(
+                "Sweep: tenant=%s cannot send external form emails; parked %s request(s) as"
+                " smtp_unconfigured and stopped retrying them. %s"
+                " Fix this under Configuration > Secrets to resume delivery.",
+                tenant_id,
+                parked,
+                readiness["reason"],
+            )
+            continue
+
+        for _request_id, reference_id in rows:
+            try:
+                result = _notify_one(tenant_id, reference_id)
+                logger.info("Sweep notify reference=%s…: %s", reference_id[:8], result)
+            except Exception:
+                logger.exception("Sweep notify failed for reference=%s… (tenant=%s)", reference_id[:8], tenant_id)
 
 
 async def sweep_loop() -> None:


### PR DESCRIPTION
## JIRA Ticket

https://aottech.atlassian.net/browse/M8F-434
<img width="1915" height="774" alt="image" src="https://github.com/user-attachments/assets/0bb5e835-052c-4b91-ae07-54bbc1b8595b" />
<img width="1914" height="848" alt="image" src="https://github.com/user-attachments/assets/4f18d5c2-5f5d-46ef-a9f1-ce0fc1e9228f" />

## Description

## 📌 Summary

This PR addresses and fixes issues around external form email notifications when a tenant lacks valid SMTP configuration. Previously, when SMTP secrets were missing or unreadable, notification jobs would fail silently or enter an indefinite retry loop during background sweeps.

This change introduces:
1. **Explicit `smtp_unconfigured` Status & Auto-Revive**: Requests that cannot be sent due to missing tenant SMTP credentials are moved to `smtp_unconfigured` with bounded error diagnostics (`last_error`), preventing infinite retry loops. Once the tenant's SMTP secrets are configured, background sweeps automatically revive parked requests.
2. **Admin API & Resend Capabilities**: New secure endpoints to check tenant SMTP readiness, list paginated notification logs (with `reference_id` redacted for security), and manually requeue/resend notifications.
3. **BPMN Modeler & UI Feedback**: Visual warnings in the BPMN properties panel when configuring external forms without SMTP configured, and real-time status banners on the [SecretList](file:///d:/m8flow/m8flow-frontend/src/views/SecretList.tsx) page indicating missing/configured `NATS_SMTP_*` keys.
4. **Security & Tenant Isolation**: Secure handling of bearer tokens (`reference_id` is never exposed to admin APIs, and access to parked links is strictly blocked until sent).

---

## 🔍 Key Changes by Area

### 1. Backend (`m8flow-backend`)

- **Database Model & Migration** ([`external_form_request.py`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/models/external_form_request.py), [`r1k2l3m4n5o6_add_external_form_request_last_error.py`](file:///d:/m8flow/m8flow-backend/migrations/versions/r1k2l3m4n5o6_add_external_form_request_last_error.py)):
  - Added `ExternalFormRequestStatus.smtp_unconfigured` status.
  - Added `OPEN_STATUSES` grouping to ensure parked requests maintain deduplication, TTL expiration, and sibling superseding.
  - Added `last_error` (max 500 characters) column to store human-readable failure diagnostics without persisting sensitive secret values.
  - Added `to_admin_dict()` serializer that deliberately omits the bearer `reference_id`.

- **Services** ([`external_form_notification_service.py`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/services/external_form_notification_service.py), [`external_form_service.py`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/services/external_form_service.py)):
  - Added `smtp_readiness()` to validate existence and decryptability of required (`NATS_SMTP_HOST`, `NATS_SMTP_PORT`, `NATS_SMTP_FROM`) and optional keys.
  - Added `mark_smtp_unconfigured()` to park requests without consuming unnecessary SMTP retries.
  - Added `revive_smtp_unconfigured()` to auto-revive parked requests into `pending` state when secrets are resolved.
  - Added `requeue()` for admin-triggered resends.
  - Blocked unauthenticated link retrieval/submission for rows in `smtp_unconfigured` state to prevent unauthorized link execution.

- **Controllers, Routes & Permissions** ([`external_form_notifications_controller.py`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/routes/external_form_notifications_controller.py), [`api.yml`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/api.yml), [`m8flow.yml`](file:///d:/m8flow/m8flow-backend/src/m8flow_backend/config/permissions/m8flow.yml)):
  - `GET /m8flow/external-form-notifications/smtp-status`: Returns tenant SMTP configuration readiness (key names only, no secrets).
  - `GET /m8flow/external-form-notifications`: Paginated list of external form requests with filtering by instance and status.
  - `POST /m8flow/external-form-notifications/{request_id}/resend`: Allows admins to requeue eligible notifications.
  - Enforced RBAC permissions (`read-external-form-smtp-status`, `read-external-form-notifications`, `resend-external-form-notifications`).

---

### 2. NATS Consumer / Background Worker (`m8flow-nats-consumer`)

- **Optimized Sweep & Tenant Lifecycle** ([`notification_worker.py`](file:///d:/m8flow/m8flow-nats-consumer/notification_worker.py)):
  - Groups pending notification candidates by tenant during background sweep passes to resolve SMTP credentials once per tenant instead of per notification.
  - Added `_revive_reconfigured_tenants()` pass at the start of each sweep cycle to immediately revive requests as soon as an administrator sets up tenant secrets.
  - If a tenant lacks SMTP configuration, all pending requests are batch-parked into `smtp_unconfigured` with structured error logging.

---

### 3. Frontend (`m8flow-frontend`)

- **BPMN Modeler Warnings** ([`ExternalFormPropertiesProvider.js`](file:///d:/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.js), [`ExternalFormSmtpStatus.jsx`](file:///d:/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.jsx)):
  - Displays a warning badge `⚠` on the **Web Form (External Form)** group header if SMTP is unconfigured for the tenant.
  - Modeler property panel displays details listing which `NATS_SMTP_*` keys must be configured under Secrets.
- **Secret Management Alerts** ([`SecretList.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/SecretList.tsx)):
  - Renders an informative/warning banner informing tenant administrators whether external form emails are ready or missing required configuration keys.
  - Auto-invalidates cached SMTP readiness when switching tenants or when creating/updating/deleting secrets in [`SecretShow.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/SecretShow.tsx) and [`ConnectorConfigure.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/ConnectorConfigure.tsx).
- **Service Layer & Permissions** ([`ExternalFormNotificationService.ts`](file:///d:/m8flow/m8flow-frontend/src/services/ExternalFormNotificationService.ts), [`M8flowUriListForPermissions.tsx`](file:///d:/m8flow/m8flow-frontend/src/hooks/M8flowUriListForPermissions.tsx), [`translation.json`](file:///d:/m8flow/m8flow-frontend/src/locales/en_us/translation.json)):
  - Implemented client API service with promise-caching per tenant and manual cache invalidation methods.

---

## 🔒 Security & Multi-Tenancy Considerations

- **Credential Redaction**: `reference_id` acts as a bearer token for form submission and is **never** exposed via the admin API list or resend responses.
- **Tenant Isolation**: Explicit tenant filtering (`m8f_tenant_id`) enforced across all updates, bulk sweeps, and controller actions. Super-admin queries must specify target tenants for resend/status endpoints.
- **No Secret Leaks**: Diagnostic `last_error` and `/smtp-status` endpoints return key names and sanitized validation messages; raw secret values or passwords are never returned or stored in plaintext.

---

## 🧪 Testing & Verification

### Backend Tests
- `pytest` unit & integration suites added/updated:
  - [`test_external_form_request.py`](file:///d:/m8flow/m8flow-backend/tests/unit/m8flow_backend/models/test_external_form_request.py): Validates open/actionable status predicates and `to_admin_dict()` payload redaction.
  - [`test_external_form_notifications_controller.py`](file:///d:/m8flow/m8flow-backend/tests/unit/m8flow_backend/routes/test_external_form_notifications_controller.py): Validates status retrieval, paginated listing, super-admin tenant attribution, and resend endpoints.
  - [`test_external_form_notification_service.py`](file:///d:/m8flow/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_notification_service.py): Validates readiness checks, error truncation, `mark_smtp_unconfigured`, `revive_smtp_unconfigured`, and `requeue`.
  - [`test_external_form_service.py`](file:///d:/m8flow/m8flow-backend/tests/unit/m8flow_backend/services/test_external_form_service.py): Validates link TTL expiry, deduplication, and suppression of unnotified parked links.
  - [`test_external_form_last_error_migration.py`](file:///d:/m8flow/m8flow-backend/tests/unit/m8flow_backend/test_external_form_last_error_migration.py): Validates Alembic upgrade and downgrade operations.

### Frontend Tests
- `npm test` suites added/updated:
  - [`ExternalFormNotificationService.test.ts`](file:///d:/m8flow/m8flow-frontend/src/services/ExternalFormNotificationService.test.ts)
  - [`ExternalFormPropertiesProvider.test.ts`](file:///d:/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormPropertiesProvider.test.ts)
  - [`ExternalFormSmtpStatus.test.tsx`](file:///d:/m8flow/m8flow-frontend/src/components/bpmn/ExternalFormSmtpStatus.test.tsx)
  - [`SecretList.test.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/SecretList.test.tsx)
  - [`SecretShow.test.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/SecretShow.test.tsx)
  - [`ConnectorConfigure.test.tsx`](file:///d:/m8flow/m8flow-frontend/src/views/ConnectorConfigure.test.tsx)

---

## 📦 Database Migrations
- **Revision**: `r1k2l3m4n5o6` (`add_external_form_request_last_error`)
- **Down Revision**: `q0j1k2l3m4n5`
- **Reversible**: Yes (downgrade safely drops `last_error` column).

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

<!-- How was this tested? -->


## Related Issues

Closes #

