### PR TITLE
fixed documentation

### DIFF
--- a/docs/shared-realm-organization-group-role-mapping.md
+++ b/docs/shared-realm-organization-group-role-mapping.md
@@ -71,6 +71,59 @@ but you do **not** see:
 
 inside the token payload.
 
+### This Is Not A Temporary Omission
+
+It is a recurring assumption that the roles could simply be added to the token so
+the backend can skip the Keycloak lookup. They cannot, for two independent
+reasons.
+
+**1. No protocol mapper can carry group attributes into a token.**
+
+Keycloak's organization mappers emit membership only:
+
+- `oidc-organization-membership-mapper` — organization alias/id, with options for
+  organization-level attributes, not group-level ones
+- `oidc-organization-group-membership-mapper` — group names/paths only
+
+The same is true of the custom mappers in `keycloak-extensions/`
+(`NormalizedGroupMembershipMapper`, `NormalizedOrganizationMembershipMapper`,
+`RealmInfoMapper`): they emit or post-process group paths and realm identity
+claims, and none of them read group attributes.
+
+**2. The realm-role route that would populate `roles` is blocked upstream.**
+
+There *is* a `roles` claim mapper on the backend client
+(`oidc-usermodel-realm-role-mapper`), and the six tenant roles do exist as realm
+roles in the tenant realm template. If organization groups could be granted realm
+roles, group membership would produce `roles: ["reviewer", ...]` in the token
+automatically, with no new mapper.
+
+Keycloak 26 does not allow it. The standard
+`/groups/{id}/role-mappings/realm` endpoint rejects organization-owned groups
+("Cannot manage organization related group via non Organization API"), and there
+is no organization-scoped equivalent. Upstream tracks this at
+[keycloak#30180](https://github.com/keycloak/keycloak/issues/30180).
+
+This is why `ensure_organization_group_role_mappings()` is a documented no-op in
+the provisioning scripts:
+
+- [docker/keycloak-init-realms.sh](../docker/keycloak-init-realms.sh)
+- [docker/keycloak-entrypoint.sh](../docker/keycloak-entrypoint.sh)
+
+Storing the mapping in group attributes and resolving it server-side is the
+supported workaround, not an interim shortcut. Until keycloak#30180 ships, a
+token-side role claim would require a new custom Java mapper that reads the group
+attributes inside Keycloak — which performs the same attribute read, just on the
+other side of the wire.
+
+Note that the backend *does* honour a top-level `roles` claim when one is present:
+`_normalize_keycloak_roles()` in
+[authorization_service_patch.py](../m8flow-backend/src/m8flow_backend/services/authorization_service_patch.py)
+treats it as authoritative, filtered against the known M8Flow role names. Nothing
+in the current provisioning path populates it with tenant roles, so in practice it
+carries only `default-roles-m8flow` (see
+[Why The Top-Level `roles` Claim Still Looks Small](#why-the-top-level-roles-claim-still-looks-small)).
+
 ## Important Distinction: This Token Is An M8Flow Token
 
 The payload you pasted has:
@@ -302,8 +355,8 @@ Given:
 
 - `mary` is in `Approvers`, `Finance`, and `HR`
 - `Approvers` explicitly maps to `editor`, `integrator`, `reviewer`
-- `Finance` maps to `reviewer`
-- `HR` maps to `reviewer`
+- `Finance` explicitly maps to `reviewer`
+- `HR` explicitly maps to `reviewer`
 
 then the important outcome is not that those roles appear in the token
 attributes. The important outcome is that, after sign-in and tenant
@@ -312,11 +365,41 @@ tenant-scoped groups.
 
 That is what permission checks use.
 
+Note that `Finance` and `HR` grant `reviewer` here **only** because they carry
+explicit attributes. Neither name appears in
+`DEFAULT_ORGANIZATION_GROUP_TO_TENANT_ROLE`, so without
+`m8flow_role_mapping_configured = true` and `m8flow_role_names = reviewer` they
+would resolve to no roles at all and contribute only their own swimlane groups
+(`<tenant_id>:Finance`, `<tenant_id>:HR`). Only the six built-in names listed
+under [Built-in fallback mapping](#2-built-in-fallback-mapping) resolve without
+attributes.
+
+## When The Sync Runs
+
+Group-to-role resolution is not a login-only step. It runs from several entry
+points, all of which converge on `patched_create_user_from_sign_in()`:
+
+- **OIDC login return** —
+  `patched_login_return()` in
+  [authentication_controller_patch.py](../m8flow-backend/src/m8flow_backend/routes/authentication_controller_patch.py)
+- **Tenant finalization** — `_finalize_tenant_from_existing_shared_realm_session()`,
+  used by the shared-realm tenant picker without a second OIDC hop
+- **Every authenticated request** — `patched_get_user_model_from_token()` re-runs
+  the sync for tokens carrying authoritative membership claims, and enriches thin
+  tokens first via `_enrich_shared_realm_token_for_active_tenant()`
+- **`GET /v1.0/status`** — the frontend access gate in
+  [health_controller_patch.py](../m8flow-backend/src/m8flow_backend/routes/health_controller_patch.py)
+  syncs, and syncs a second time as a retry if the `/frontend-access` read is denied
+
+The practical consequence: a Keycloak role-attribute change generally takes effect
+on the user's **next request**, not on their next login.
+
 ## Operational Notes
 
-- If you change organization-group role attributes in Keycloak, the user usually
-  needs a fresh login or tenant-finalization pass so M8Flow can resynchronize
-  the local mirrored groups.
+- If you change organization-group role attributes in Keycloak, the change is
+  normally picked up on the user's next authenticated request, because the
+  request-time sync above re-resolves the mapping. A fresh login or
+  tenant-finalization pass forces it immediately.
 - If a custom group does not grant the expected permissions, verify the group
   has:
   - `m8flow_role_mapping_configured = true`


### PR DESCRIPTION
## JIRA Ticket

https://aottech.atlassian.net/browse/M8F-330
## Description
## Summary

The ticket asked to map user roles directly from the authentication token instead of
looking them up in Keycloak, on the stated premise that *"user groups are available in
the authentication token; however, roles are retrieved from Keycloak using the
`roles_for_group()` method."*

**Investigation showed the premise is incorrect: roles are not in the token, and cannot
be put there with the current Keycloak version.** Rather than implement a change based on
a false premise, this PR documents the actual mechanism and *why* the token-side approach
is blocked, so the same assumption does not resurface.

This is a **documentation-only** change. No code was modified.

---

## What the ticket got wrong

### 1. The token does not carry role information

The token carries **group membership only**:

```json
{
  "organization": {
    "org1": {
      "id": "a787d38c-53fe-44d7-992d-5b2e8e590cec",
      "groups": ["Approvers", "Finance", "HR"]
    }
  }
}
```

Roles live in Keycloak **organization-group attributes** (`m8flow_role_names`,
`m8flow_role_mapping_configured`), which are read server-side. The token contains group
*names*, never the group *configuration*.

### 2. No protocol mapper can carry group attributes into a token

Keycloak's organization mappers emit membership only:

| Mapper | Emits |
| --- | --- |
| `oidc-organization-membership-mapper` | organization alias/id (org-level attributes only, not group-level) |
| `oidc-organization-group-membership-mapper` | group names/paths only |

The three custom mappers in `keycloak-extensions/`
(`NormalizedGroupMembershipMapper`, `NormalizedOrganizationMembershipMapper`,
`RealmInfoMapper`) emit or post-process group paths and realm identity claims. None reads
group attributes.

### 3. The realm-role route that *would* work is blocked upstream

A `roles` claim mapper (`oidc-usermodel-realm-role-mapper`) already exists on the backend
client, and the six tenant roles already exist as realm roles in the tenant realm
template. If organization groups could be granted realm roles, group membership would
produce `roles: ["reviewer", ...]` in the token automatically — no new mapper needed.

Keycloak 26 does not allow it. The standard `/groups/{id}/role-mappings/realm` endpoint
rejects organization-owned groups (*"Cannot manage organization related group via non
Organization API"*), and there is no organization-scoped equivalent. Tracked upstream at
[keycloak#30180](https://github.com/keycloak/keycloak/issues/30180).

This is why `ensure_organization_group_role_mappings()` is already a **documented no-op**
in `docker/keycloak-init-realms.sh` and `docker/keycloak-entrypoint.sh`.

Storing the mapping in group attributes and resolving it server-side is the supported
workaround, not an interim shortcut. A token-side role claim would require a new custom
Java mapper reading the same group attributes inside Keycloak — the identical attribute
read, just on the other side of the wire.

### 4. `roles_for_group()` does not exist

The ticket names `roles_for_group()`. The actual functions are `_roles_for_group()` and
its alias `_mapped_roles_for_group()` in `tenant_role_service.py` — both **private**, and
both serving the **tenant-management UI**, not the auth path. The auth path uses
`_shared_realm_role_identifiers_from_organization_groups()` in
`authorization_service_patch.py`. Removing or minimising `_roles_for_group()` would not
affect authentication performance at all.

---

## What was implemented

Corrections and additions to
`docs/shared-realm-organization-group-role-mapping.md`:

### 1. New section: *This Is Not A Temporary Omission*

Documents all three blockers above (mapper limitations, keycloak#30180, the no-op
provisioning function) so the "just put roles in the token" assumption does not recur.

Also records a genuine subtlety found while reading: the backend **does** honour a
top-level `roles` claim when present — `_normalize_keycloak_roles()` treats it as
authoritative, filtered against known M8Flow role names. Nothing in the current
provisioning path populates it with tenant roles, so in practice it carries only
`default-roles-m8flow`.

### 2. New section: *When The Sync Runs*

The doc previously implied role resolution was a login-time step. It runs from four entry
points, all converging on `patched_create_user_from_sign_in()`:

- OIDC login return (`patched_login_return()`)
- Tenant finalization (`_finalize_tenant_from_existing_shared_realm_session()`)
- **Every authenticated request** (`patched_get_user_model_from_token()`)
- `GET /v1.0/status` — the frontend access gate, which syncs twice if the
  `/frontend-access` read is denied

### 3. Corrected a stale operational note

Previously: a role-attribute change *"usually needs a fresh login or tenant-finalization
pass"*. Request-time enrichment means it is normally picked up on the user's **next
request**; login/finalization merely forces it immediately.

### 4. Corrected the `mary` example

The example claimed `Finance -> reviewer` and `HR -> reviewer`. Neither name appears in
`DEFAULT_ORGANIZATION_GROUP_TO_TENANT_ROLE`, so those mappings hold **only** via explicit
attributes. Without them, both groups grant no roles and contribute only their own
swimlane groups (`<tenant_id>:Finance`, `<tenant_id>:HR`).

---

## Files changed

- `docs/shared-realm-organization-group-role-mapping.md`

## Not changed

No code, tests, configuration, or Keycloak assets. In particular the auth-path role
resolution in `authorization_service_patch.py` is untouched.

---

## Follow-up work identified (not in this PR)

The ticket's underlying goal — *"improving authentication performance"* by *"reducing
Keycloak API calls"* — is valid and **unaddressed by this PR**. The real cost is an N+1
lookup, not the token/lookup distinction:

`_shared_realm_role_identifiers_from_organization_groups()` does, **per group, per
authenticated request**:

1. `get_organization_group_by_name` → `GET .../organizations/{org}/groups?search=`
2. `get_organization_group_by_id` → `GET .../organizations/{org}/groups/{gid}`
   (required because the brief list omits `attributes`)
3. plus an **uncached** `get_master_admin_token()` password grant, since no `admin_token`
   is threaded through

A user in 3 groups costs roughly **9 outbound Keycloak calls on every protected
request**. A batched, briefly-cached per-organization lookup (invalidated on group
create/rename/delete/role-write) would reduce this to ~2 cold and 0 warm, with an
identical resolved role set and therefore no RBAC change.

Two pre-existing issues also surfaced, both unrelated to this change:

- `M8FLOW_TENANT_ROLE_ALIASES` omits `submitter`, so `submitter@<tenant>` in
  `realm_access.roles` is silently dropped. It is present in
  `M8FLOW_ROLE_GROUP_IDENTIFIERS` and `VALID_TENANT_ROLE_NAMES`.
- `get_group_realm_role_mappings()` / `add_group_realm_role_mapping()` /
  `remove_group_realm_role_mapping()` in `keycloak_service.py` have tests but **no
  production callers** — dead code from the blocked realm-role approach.

---

## Acceptance criteria status

| Criterion | Status |
| --- | --- |
| Roles mapped from the authentication token | **Not achievable** — see blockers above; documented instead |
| Authorization and RBAC behaviour unchanged | Met (no code changed) |
| `roles_for_group()` dependency removed/minimised | **N/A** — function is UI-path, not auth-path |
| Authentication performance improved | **Not addressed** — requires the batching/caching follow-up |
| Existing access and permissions continue to function | Met (no code changed) |
| Regression testing completed | N/A for a docs-only change |
| Documentation updated | Met |

## Testing

Markdown-only change; the repo has no doc-lint target. Verified manually that all
headings, both intra-document anchors, and all four file links resolve.



## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- [ ] Backend
- [ ] Frontend
- [ ] Documentation

## Testing

<!-- How was this tested? -->


## Related Issues

Closes #

